### PR TITLE
Fixed Headers not being set post init

### DIFF
--- a/src/ASAPIClient+Network.m
+++ b/src/ASAPIClient+Network.m
@@ -50,6 +50,7 @@
 {
     assert(index < [self.operationManagers count]);
     AFHTTPRequestOperationManager *httpRequestOperationManager = [self.operationManagers objectAtIndex:index];
+    [self updateHeaders:httpRequestOperationManager];
     NSMutableURLRequest *request = [httpRequestOperationManager.requestSerializer requestWithMethod:method URLString:[[NSURL URLWithString:path relativeToURL:httpRequestOperationManager.baseURL] absoluteString]  parameters:body error:nil];
     
     AFHTTPRequestOperation *operation = [httpRequestOperationManager HTTPRequestOperationWithRequest:request success:^(AFHTTPRequestOperation *operation, id JSON) {

--- a/src/ASAPIClient.h
+++ b/src/ASAPIClient.h
@@ -271,4 +271,8 @@
  */
 @property (strong, nonatomic) NSString *userToken;
 
+
+
+-(void) updateHeaders:(AFHTTPRequestOperationManager *)httpRequestOperationManager;
+
 @end

--- a/src/ASAPIClient.m
+++ b/src/ASAPIClient.m
@@ -119,14 +119,7 @@
             AFHTTPRequestOperationManager *httpRequestOperationManager = [[AFHTTPRequestOperationManager alloc] initWithBaseURL:url];
             httpRequestOperationManager.responseSerializer = [AFJSONResponseSerializer serializer];
             httpRequestOperationManager.requestSerializer = [AFJSONRequestSerializer serializer];
-            [httpRequestOperationManager.requestSerializer setValue:self.apiKey forHTTPHeaderField:@"X-Algolia-API-Key"];
-            [httpRequestOperationManager.requestSerializer setValue:self.applicationID forHTTPHeaderField:@"X-Algolia-Application-Id"];
-            if (self.tagFilters != nil) {
-                [httpRequestOperationManager.requestSerializer setValue:self.tagFilters forHTTPHeaderField:@"X-Algolia-TagFilters"];
-            }
-            if (self.userToken != nil) {
-                [httpRequestOperationManager.requestSerializer setValue:self.userToken forHTTPHeaderField:@"X-Algolia-UserToken"];
-            }
+            [self updateHeaders:httpRequestOperationManager];
             [httpRequestOperationManagers addObject:httpRequestOperationManager];
         }
         operationManagers = httpRequestOperationManagers;
@@ -134,6 +127,17 @@
     return self;
 }
 
+-(void) updateHeaders:(AFHTTPRequestOperationManager *)httpRequestOperationManager{
+    [httpRequestOperationManager.requestSerializer setValue:self.apiKey forHTTPHeaderField:@"X-Algolia-API-Key"];
+    [httpRequestOperationManager.requestSerializer setValue:self.applicationID forHTTPHeaderField:@"X-Algolia-Application-Id"];
+    if (self.tagFilters != nil) {
+        [httpRequestOperationManager.requestSerializer setValue:self.tagFilters forHTTPHeaderField:@"X-Algolia-TagFilters"];
+    }
+    if (self.userToken != nil) {
+        [httpRequestOperationManager.requestSerializer setValue:self.userToken forHTTPHeaderField:@"X-Algolia-UserToken"];
+    }
+
+}
 -(void) multipleQueries:(NSArray*)queries
                 success:(void(^)(ASAPIClient *client, NSArray *queries, NSDictionary *result))success
                 failure: (void(^)(ASAPIClient *client, NSArray *queries, NSString *errorMessage))failure


### PR DESCRIPTION
We found a problem.  When you set the tagfilters in the client it was never sending them to the server.  
This was due to the headers only being set on inti method.