### PR TITLE
Changed every network method to return an AFHTTPRequestOperation; Added possibility to API client to avoid starting operations if needed for developer; Some other changes

### DIFF
--- a/src/ASAPIClient+Network.h
+++ b/src/ASAPIClient+Network.h
@@ -34,7 +34,7 @@
 /**
  * Perform an HTTP query
  */
--(void) performHTTPQuery:(NSString*)path method:(NSString*)method body:(NSDictionary*)body managers:(NSArray*)managers index:(NSUInteger)index timeout:(NSTimeInterval)timeout
+-(AFHTTPRequestOperation *) performHTTPQuery:(NSString*)path method:(NSString*)method body:(NSDictionary*)body managers:(NSArray*)managers index:(NSUInteger)index timeout:(NSTimeInterval)timeout
                  success:(void(^)(id JSON))success failure:(void(^)(NSString *errorMessage))failure;
 
 -(void) cancelQueries:(NSString*)method path:(NSString*)path;

--- a/src/ASAPIClient+Network.m
+++ b/src/ASAPIClient+Network.m
@@ -55,7 +55,7 @@
     }
 }
 
--(void) performHTTPQuery: (NSString*)path method:(NSString*)method body:(NSDictionary*)body managers:(NSArray*)managers index:(NSUInteger)index timeout:(NSTimeInterval)timeout
+-(AFHTTPRequestOperation *) performHTTPQuery: (NSString*)path method:(NSString*)method body:(NSDictionary*)body managers:(NSArray*)managers index:(NSUInteger)index timeout:(NSTimeInterval)timeout
                  success:(void(^)(id JSON))success failure:(void(^)(NSString *errorMessage))failure
 {
     assert(index < [managers count]);
@@ -84,6 +84,7 @@
     }];
     
     [httpRequestOperationManager.operationQueue addOperation:operation];
+    return operation;
 }
 
 @end

--- a/src/ASAPIClient+Network.m
+++ b/src/ASAPIClient+Network.m
@@ -83,7 +83,10 @@
         }
     }];
     
-    [httpRequestOperationManager.operationQueue addOperation:operation];
+    if (!self.startOperationsManually) {
+        [httpRequestOperationManager.operationQueue addOperation:operation];
+    }
+    
     return operation;
 }
 

--- a/src/ASAPIClient.h
+++ b/src/ASAPIClient.h
@@ -88,8 +88,8 @@ FOUNDATION_EXPORT NSString *const Version;
  * { "items": [ {"name": "contacts", "createdAt": "2013-01-18T15:33:13.556Z"},
  *              {"name": "notes", "createdAt": "2013-01-18T15:33:13.556Z"}]}
  */
--(void) listIndexes:(void(^)(ASAPIClient *client, NSDictionary *result))success
-                    failure:(void(^)(ASAPIClient *client, NSString *errorMessage))failure;
+-(AFHTTPRequestOperation *) listIndexes:(void(^)(ASAPIClient *client, NSDictionary *result))success
+                                failure:(void(^)(ASAPIClient *client, NSString *errorMessage))failure;
 
 /**
  * Delete an index
@@ -97,9 +97,9 @@ FOUNDATION_EXPORT NSString *const Version;
  * @param indexName the name of index to delete
  * return an object containing a "deletedAt" attribute in the success block
  */
--(void) deleteIndex:(NSString*)indexName
-            success:(void(^)(ASAPIClient *client, NSString *indexName, NSDictionary *result))success
-            failure:(void(^)(ASAPIClient *client, NSString *indexName, NSString *errorMessage))failure;
+-(AFHTTPRequestOperation *) deleteIndex:(NSString*)indexName
+                                success:(void(^)(ASAPIClient *client, NSString *indexName, NSDictionary *result))success
+                                failure:(void(^)(ASAPIClient *client, NSString *indexName, NSString *errorMessage))failure;
 
 /**
  * Move an existing index.
@@ -107,24 +107,26 @@ FOUNDATION_EXPORT NSString *const Version;
  * @param srcIndexName the name of index to copy.
  * @param dstIndexName the new index name that will contains srcIndexName (destination will be overriten if it already exist).
  */
--(void) moveIndex:(NSString*)srcIndexName to:(NSString*)dstIndexName
-            success:(void(^)(ASAPIClient *client, NSString *srcIndexName, NSString *dstIndexName, NSDictionary *result))success
-            failure:(void(^)(ASAPIClient *client, NSString *srcIndexName, NSString *dstIndexName, NSString *errorMessage))failure;
+-(AFHTTPRequestOperation *) moveIndex:(NSString*)srcIndexName
+                                   to:(NSString*)dstIndexName
+                              success:(void(^)(ASAPIClient *client, NSString *srcIndexName, NSString *dstIndexName, NSDictionary *result))success
+                              failure:(void(^)(ASAPIClient *client, NSString *srcIndexName, NSString *dstIndexName, NSString *errorMessage))failure;
 /**
  * Copy an existing index.
  *
  * @param srcIndexName the name of index to copy.
  * @param dstIndexName the new index name that will contains a copy of srcIndexName (destination will be overriten if it already exist).
  */
--(void) copyIndex:(NSString*)srcIndexName to:(NSString*)dstIndexName
-          success:(void(^)(ASAPIClient *client, NSString *srcIndexName, NSString *dstIndexName, NSDictionary *result))success
-          failure:(void(^)(ASAPIClient *client, NSString *srcIndexName, NSString *dstIndexName, NSString *errorMessage))failure;
+-(AFHTTPRequestOperation *) copyIndex:(NSString*)srcIndexName
+                                   to:(NSString*)dstIndexName
+                              success:(void(^)(ASAPIClient *client, NSString *srcIndexName, NSString *dstIndexName, NSDictionary *result))success
+                              failure:(void(^)(ASAPIClient *client, NSString *srcIndexName, NSString *dstIndexName, NSString *errorMessage))failure;
 
 /**
  * Return 10 last log entries.
  */
--(void) getLogs:(void(^)(ASAPIClient *client, NSDictionary *result))success
-          failure:(void(^)(ASAPIClient *client, NSString *errorMessage))failure;
+-(AFHTTPRequestOperation *) getLogs:(void(^)(ASAPIClient *client, NSDictionary *result))success
+                            failure:(void(^)(ASAPIClient *client, NSString *errorMessage))failure;
 
 /**
  * Return last logs entries.
@@ -132,9 +134,10 @@ FOUNDATION_EXPORT NSString *const Version;
  * @param offset Specify the first entry to retrieve (0-based, 0 is the most recent log entry).
  * @param length Specify the maximum number of entries to retrieve starting at offset. Maximum allowed value: 1000.
  */
--(void) getLogsWithOffset:(NSUInteger)offset length:(NSUInteger)length
-        success:(void(^)(ASAPIClient *client, NSUInteger offset, NSUInteger length, NSDictionary *result))success
-        failure:(void(^)(ASAPIClient *client, NSUInteger offset, NSUInteger length, NSString *errorMessage))failure;
+-(AFHTTPRequestOperation *) getLogsWithOffset:(NSUInteger)offset
+                                       length:(NSUInteger)length
+                                      success:(void(^)(ASAPIClient *client, NSUInteger offset, NSUInteger length, NSDictionary *result))success
+                                      failure:(void(^)(ASAPIClient *client, NSUInteger offset, NSUInteger length, NSString *errorMessage))failure;
 
 /**
  * Return last logs entries.
@@ -142,9 +145,11 @@ FOUNDATION_EXPORT NSString *const Version;
  * @param offset Specify the first entry to retrieve (0-based, 0 is the most recent log entry).
  * @param length Specify the maximum number of entries to retrieve starting at offset. Maximum allowed value: 1000.
  */
--(void) getLogsWithType:(NSUInteger)offset length:(NSUInteger)length type:(NSString*)type
-                  success:(void(^)(ASAPIClient *client, NSUInteger offset, NSUInteger length, NSString* type, NSDictionary *result))success
-                  failure:(void(^)(ASAPIClient *client, NSUInteger offset, NSUInteger length, NSString* type, NSString *errorMessage))failure;
+-(AFHTTPRequestOperation *) getLogsWithType:(NSUInteger)offset
+                                     length:(NSUInteger)length
+                                       type:(NSString*)type
+                                    success:(void(^)(ASAPIClient *client, NSUInteger offset, NSUInteger length, NSString* type, NSDictionary *result))success
+                                    failure:(void(^)(ASAPIClient *client, NSUInteger offset, NSUInteger length, NSString* type, NSString *errorMessage))failure;
 
 /**
  * Get the index object initialized (no server call needed for initialization)
@@ -166,9 +171,9 @@ FOUNDATION_EXPORT NSString *const Version;
  *
  * @param query contains an array of queries with the associated index (NSArray of NSDictionary object @{"indexName":@"targettedIndex", @"query": theASQueryObject }).
  */
--(void) multipleQueries:(NSArray*)query
-                        success:(void(^)(ASAPIClient *client, NSArray *queries, NSDictionary *result))success
-                        failure: (void(^)(ASAPIClient *client, NSArray *queries, NSString *errorMessage))failure;
+-(AFHTTPRequestOperation *) multipleQueries:(NSArray*)query
+                                    success:(void(^)(ASAPIClient *client, NSArray *queries, NSDictionary *result))success
+                                    failure: (void(^)(ASAPIClient *client, NSArray *queries, NSString *errorMessage))failure;
 
 /**
  * Query multiple indexes with one API call
@@ -176,27 +181,30 @@ FOUNDATION_EXPORT NSString *const Version;
  * @param query contains an array of queries with the associated index (NSArray of NSDictionary object @{"indexName":@"targettedIndex", @"query": theASQueryObject }).
  * @param strategy name of the strategy applied to the sequence of queries default:none
  */
--(void) multipleQueries:(NSArray*)query withStrategy:(NSString*)strategy
-                success:(void(^)(ASAPIClient *client, NSArray *queries, NSString* strategy, NSDictionary *result))success
-                failure: (void(^)(ASAPIClient *client, NSArray *queries, NSString* strategy, NSString *errorMessage))failure;
+-(AFHTTPRequestOperation *) multipleQueries:(NSArray*)query
+                               withStrategy:(NSString*)strategy
+                                    success:(void(^)(ASAPIClient *client, NSArray *queries, NSString* strategy, NSDictionary *result))success
+                                    failure: (void(^)(ASAPIClient *client, NSArray *queries, NSString* strategy, NSString *errorMessage))failure;
 
 /**
  * List all existing user keys with their associated ACLs
  */
--(void) listUserKeys:(void(^)(ASAPIClient *client, NSDictionary *result))success
-                     failure:(void(^)(ASAPIClient *client, NSString *errorMessage))failure;
+-(AFHTTPRequestOperation *) listUserKeys:(void(^)(ASAPIClient *client, NSDictionary *result))success
+                                 failure:(void(^)(ASAPIClient *client, NSString *errorMessage))failure;
 
 /**
  * Get ACL of a user key
  */
--(void) getUserKeyACL:(NSString*)key success:(void(^)(ASAPIClient *client, NSString *key, NSDictionary *result))success
-                                     failure:(void(^)(ASAPIClient *client, NSString *key, NSString *errorMessage))failure;
+-(AFHTTPRequestOperation *) getUserKeyACL:(NSString*)key
+                                  success:(void(^)(ASAPIClient *client, NSString *key, NSDictionary *result))success
+                                  failure:(void(^)(ASAPIClient *client, NSString *key, NSString *errorMessage))failure;
 
 /**
  * Delete an existing user key
  */
--(void) deleteUserKey:(NSString*)key success:(void(^)(ASAPIClient *client, NSString *key, NSDictionary *result))success
-                                     failure:(void(^)(ASAPIClient *client, NSString *key, NSString *errorMessage))failure;
+-(AFHTTPRequestOperation *) deleteUserKey:(NSString*)key
+                                  success:(void(^)(ASAPIClient *client, NSString *key, NSDictionary *result))success
+                                  failure:(void(^)(ASAPIClient *client, NSString *key, NSString *errorMessage))failure;
 
 /**
  * Create a new user key
@@ -210,9 +218,9 @@ FOUNDATION_EXPORT NSString *const Version;
  *   - settings : allows to get index settings (https only)
  *   - editSettings : allows to change index settings (https only)
  */
--(void) addUserKey:(NSArray*)acls
-           success:(void(^)(ASAPIClient *client, NSArray* acls, NSDictionary *result))success
-           failure:(void(^)(ASAPIClient *client, NSArray* acls, NSString *errorMessage))failure;
+-(AFHTTPRequestOperation *) addUserKey:(NSArray*)acls
+                               success:(void(^)(ASAPIClient *client, NSArray* acls, NSDictionary *result))success
+                               failure:(void(^)(ASAPIClient *client, NSArray* acls, NSString *errorMessage))failure;
 
 /**
  * Create a new user key
@@ -236,9 +244,10 @@ FOUNDATION_EXPORT NSString *const Version;
  *   - queryParameters: string
  *   - maxQueriesPerIPPerHour: integer
  */
--(void) addUserKey:(NSArray*)acls withParams:(NSDictionary*)params
-           success:(void(^)(ASAPIClient *client, NSArray* acls, NSDictionary* params, NSDictionary *result))success
-           failure:(void(^)(ASAPIClient *client, NSArray* acls, NSDictionary* params, NSString *errorMessage))failure;
+-(AFHTTPRequestOperation *) addUserKey:(NSArray*)acls
+                            withParams:(NSDictionary*)params
+                               success:(void(^)(ASAPIClient *client, NSArray* acls, NSDictionary* params, NSDictionary *result))success
+                               failure:(void(^)(ASAPIClient *client, NSArray* acls, NSDictionary* params, NSString *errorMessage))failure;
 
 /**
  * Create a new user key
@@ -253,11 +262,14 @@ FOUNDATION_EXPORT NSString *const Version;
  *   - editSettings : allows to change index settings (https only)
  * @param validity the number of seconds after which the key will be automatically removed (0 means no time limit for this key)
  * @param maxQueriesPerIPPerHour Specify the maximum number of API calls allowed from an IP address per hour.  Defaults to 0 (no rate limit).
- * @param maxHitsPerQuery Specify the maximum number of hits this API key can retrieve in one call. Defaults to 0 (unlimited) 
+ * @param maxHitsPerQuery Specify the maximum number of hits this API key can retrieve in one call. Defaults to 0 (unlimited)
  */
--(void) addUserKey:(NSArray*)acls withValidity:(NSUInteger)validity maxQueriesPerIPPerHour:(NSUInteger)maxQueriesPerIPPerHour maxHitsPerQuery:(NSUInteger)maxHitsPerQuery
-           success:(void(^)(ASAPIClient *client, NSArray *acls, NSDictionary *result))success
-           failure:(void(^)(ASAPIClient *client, NSArray *acls, NSString *errorMessage))failure;
+-(AFHTTPRequestOperation *) addUserKey:(NSArray*)acls
+                          withValidity:(NSUInteger)validity
+                maxQueriesPerIPPerHour:(NSUInteger)maxQueriesPerIPPerHour
+                       maxHitsPerQuery:(NSUInteger)maxHitsPerQuery
+                               success:(void(^)(ASAPIClient *client, NSArray *acls, NSDictionary *result))success
+                               failure:(void(^)(ASAPIClient *client, NSArray *acls, NSString *errorMessage))failure;
 
 /**
  * Create a new user key
@@ -275,9 +287,13 @@ FOUNDATION_EXPORT NSString *const Version;
  * @param maxQueriesPerIPPerHour Specify the maximum number of API calls allowed from an IP address per hour.  Defaults to 0 (no rate limit).
  * @param maxHitsPerQuery Specify the maximum number of hits this API key can retrieve in one call. Defaults to 0 (unlimited)
  */
--(void) addUserKey:(NSArray*)acls withIndexes:(NSArray*)indexes withValidity:(NSUInteger)validity maxQueriesPerIPPerHour:(NSUInteger)maxQueriesPerIPPerHour maxHitsPerQuery:(NSUInteger)maxHitsPerQuery
-           success:(void(^)(ASAPIClient *client, NSArray *acls, NSArray *indexes, NSDictionary *result))success
-           failure:(void(^)(ASAPIClient *client, NSArray *acls, NSArray *indexes, NSString *errorMessage))failure;
+-(AFHTTPRequestOperation *) addUserKey:(NSArray*)acls
+                           withIndexes:(NSArray*)indexes
+                          withValidity:(NSUInteger)validity
+                maxQueriesPerIPPerHour:(NSUInteger)maxQueriesPerIPPerHour
+                       maxHitsPerQuery:(NSUInteger)maxHitsPerQuery
+                               success:(void(^)(ASAPIClient *client, NSArray *acls, NSArray *indexes, NSDictionary *result))success
+                               failure:(void(^)(ASAPIClient *client, NSArray *acls, NSArray *indexes, NSString *errorMessage))failure;
 
 /**
  * Update a user key
@@ -293,9 +309,10 @@ FOUNDATION_EXPORT NSString *const Version;
  *   - queryParameters: string
  *   - maxQueriesPerIPPerHour: integer
  */
--(void) updateUserKey:(NSString*)key withParams:(NSDictionary*)params
-              success:(void(^)(ASAPIClient *client, NSString *key, NSDictionary *params, NSDictionary *result))success
-              failure:(void(^)(ASAPIClient *client, NSString *key, NSDictionary *params, NSString *errorMessage))failure;
+-(AFHTTPRequestOperation *) updateUserKey:(NSString*)key
+                               withParams:(NSDictionary*)params
+                                  success:(void(^)(ASAPIClient *client, NSString *key, NSDictionary *params, NSDictionary *result))success
+                                  failure:(void(^)(ASAPIClient *client, NSString *key, NSDictionary *params, NSString *errorMessage))failure;
 
 /**
  * Update a user key
@@ -309,8 +326,10 @@ FOUNDATION_EXPORT NSString *const Version;
  *   - settings : allows to get index settings (https only)
  *   - editSettings : allows to change index settings (https only)
  */
--(void) updateUserKey:(NSString*)key withACL:(NSArray*)acls success:(void(^)(ASAPIClient *client, NSString *key, NSArray *acls, NSDictionary *result))success
-              failure:(void(^)(ASAPIClient *client, NSString *key, NSArray *acls, NSString *errorMessage))failure;
+-(AFHTTPRequestOperation *) updateUserKey:(NSString*)key
+                                  withACL:(NSArray*)acls
+                                  success:(void(^)(ASAPIClient *clients, NSString *key, NSArray *acls, NSDictionary *result))success
+                                  failure:(void(^)(ASAPIClient *client, NSString *key, NSArray *acls, NSString *errorMessage))failure;
 
 /**
  * Update a user key
@@ -327,9 +346,13 @@ FOUNDATION_EXPORT NSString *const Version;
  * @param maxQueriesPerIPPerHour Specify the maximum number of API calls allowed from an IP address per hour.  Defaults to 0 (no rate limit).
  * @param maxHitsPerQuery Specify the maximum number of hits this API key can retrieve in one call. Defaults to 0 (unlimited)
  */
--(void) updateUserKey:(NSString*)key withACL:(NSArray*)acls withValidity:(NSUInteger)validity maxQueriesPerIPPerHour:(NSUInteger)maxQueriesPerIPPerHour maxHitsPerQuery:(NSUInteger)maxHitsPerQuery
-              success:(void(^)(ASAPIClient *client, NSString *key, NSArray *acls, NSDictionary *result))success
-              failure:(void(^)(ASAPIClient *client, NSString *key, NSArray *acls, NSString *errorMessage))failure;
+-(AFHTTPRequestOperation *) updateUserKey:(NSString*)key
+                                  withACL:(NSArray*)acls
+                             withValidity:(NSUInteger)validity
+                   maxQueriesPerIPPerHour:(NSUInteger)maxQueriesPerIPPerHour
+                          maxHitsPerQuery:(NSUInteger)maxHitsPerQuery
+                                  success:(void(^)(ASAPIClient *client, NSString *key, NSArray *acls, NSDictionary *result))success
+                                  failure:(void(^)(ASAPIClient *client, NSString *key, NSArray *acls, NSString *errorMessage))failure;
 
 /**
  * Update a user key
@@ -347,9 +370,13 @@ FOUNDATION_EXPORT NSString *const Version;
  * @param maxQueriesPerIPPerHour Specify the maximum number of API calls allowed from an IP address per hour.  Defaults to 0 (no rate limit).
  * @param maxHitsPerQuery Specify the maximum number of hits this API key can retrieve in one call. Defaults to 0 (unlimited)
  */
--(void) updateUserKey:(NSString*)key withACL:(NSArray*)acls withIndexes:(NSArray*)indexes withValidity:(NSUInteger)validity maxQueriesPerIPPerHour:(NSUInteger)maxQueriesPerIPPerHour maxHitsPerQuery:(NSUInteger)maxHitsPerQuery
-              success:(void(^)(ASAPIClient *client, NSString *key, NSArray *acls, NSArray *indexes, NSDictionary *result))success
-              failure:(void(^)(ASAPIClient *client, NSString *key, NSArray *acls, NSArray *indexes, NSString *errorMessage))failure;
+-(AFHTTPRequestOperation *) updateUserKey:(NSString*)key
+                                  withACL:(NSArray*)acls withIndexes:(NSArray*)indexes
+                             withValidity:(NSUInteger)validity
+                   maxQueriesPerIPPerHour:(NSUInteger)maxQueriesPerIPPerHour
+                          maxHitsPerQuery:(NSUInteger)maxHitsPerQuery
+                                  success:(void(^)(ASAPIClient *client, NSString *key, NSArray *acls, NSArray *indexes, NSDictionary *result))success
+                                  failure:(void(^)(ASAPIClient *client, NSString *key, NSArray *acls, NSArray *indexes, NSString *errorMessage))failure;
 
 @property (readonly, nonatomic) NSString *applicationID;
 @property (readonly, nonatomic) NSString *apiKey;

--- a/src/ASAPIClient.h
+++ b/src/ASAPIClient.h
@@ -386,6 +386,7 @@ FOUNDATION_EXPORT NSString *const Version;
 @property (readonly, nonatomic) NSArray *writeOperationManagers;
 @property NSTimeInterval timeout;
 @property NSTimeInterval searchTimeout;
+@property (assign, nonatomic) BOOL startOperationsManually;
 
 /**
  * Add security tag header (see http://www.algolia.com/doc/guides/objc#SecurityUser for more details)

--- a/src/ASAPIClient.m
+++ b/src/ASAPIClient.m
@@ -67,18 +67,18 @@ NSString *const Version = @"3.4.2";
         NSMutableArray *searchArray = nil;
         NSMutableArray *writeArray = nil;
         if (phostnames == nil) {
-             searchArray = [NSMutableArray arrayWithObjects:
-                                     [NSString stringWithFormat:@"%@-dsn.algolia.net", papplicationID],
-                                     [NSString stringWithFormat:@"%@-1.algolianet.com", papplicationID],
-                                     [NSString stringWithFormat:@"%@-2.algolianet.com", papplicationID],
-                                     [NSString stringWithFormat:@"%@-3.algolianet.com", papplicationID],
-                                     nil];
+            searchArray = [NSMutableArray arrayWithObjects:
+                           [NSString stringWithFormat:@"%@-dsn.algolia.net", papplicationID],
+                           [NSString stringWithFormat:@"%@-1.algolianet.com", papplicationID],
+                           [NSString stringWithFormat:@"%@-2.algolianet.com", papplicationID],
+                           [NSString stringWithFormat:@"%@-3.algolianet.com", papplicationID],
+                           nil];
             writeArray = [NSMutableArray arrayWithObjects:
-                     [NSString stringWithFormat:@"%@.algolia.net", papplicationID],
-                     [NSString stringWithFormat:@"%@-1.algolianet.com", papplicationID],
-                     [NSString stringWithFormat:@"%@-2.algolianet.com", papplicationID],
-                     [NSString stringWithFormat:@"%@-3.algolianet.com", papplicationID],
-                     nil];
+                          [NSString stringWithFormat:@"%@.algolia.net", papplicationID],
+                          [NSString stringWithFormat:@"%@-1.algolianet.com", papplicationID],
+                          [NSString stringWithFormat:@"%@-2.algolianet.com", papplicationID],
+                          [NSString stringWithFormat:@"%@-3.algolianet.com", papplicationID],
+                          nil];
         } else {
             searchArray = writeArray = [NSMutableArray arrayWithArray:phostnames];
         }
@@ -90,7 +90,7 @@ NSString *const Version = @"3.4.2";
         }
         _writeHostnames = writeArray;
         _searchHostnames = searchArray;
-
+        
         if (self.applicationID == nil || [self.applicationID length] == 0)
             @throw [NSException exceptionWithName:@"InvalidArgument" reason:@"Application ID must be set" userInfo:nil];
         if (self.apiKey == nil || [self.apiKey length] == 0)
@@ -149,11 +149,11 @@ NSString *const Version = @"3.4.2";
     }
 }
 
--(void) multipleQueries:(NSArray*)queries
-                success:(void(^)(ASAPIClient *client, NSArray *queries, NSDictionary *result))success
-                failure: (void(^)(ASAPIClient *client, NSArray *queries, NSString *errorMessage))failure
+-(AFHTTPRequestOperation *) multipleQueries:(NSArray*)queries
+                                    success:(void(^)(ASAPIClient *client, NSArray *queries, NSDictionary *result))success
+                                    failure:(void(^)(ASAPIClient *client, NSArray *queries, NSString *errorMessage))failure
 {
-    [self multipleQueries:queries withStrategy:@"none" success:^(ASAPIClient *client, NSArray *queries, NSString *strategy, NSDictionary *result) {
+    return [self multipleQueries:queries withStrategy:@"none" success:^(ASAPIClient *client, NSArray *queries, NSString *strategy, NSDictionary *result) {
         if (success != nil)
             success(client, queries, result);
     } failure:^(ASAPIClient *client, NSArray *queries, NSString *strategy, NSString *errorMessage) {
@@ -162,9 +162,9 @@ NSString *const Version = @"3.4.2";
     }];
 }
 
--(void) multipleQueries:(NSArray*)queries withStrategy:(NSString*)strategy
-                success:(void(^)(ASAPIClient *client, NSArray *queries, NSString* strategy, NSDictionary *result))success
-                failure: (void(^)(ASAPIClient *client, NSArray *queries, NSString* strategy, NSString *errorMessage))failure
+-(AFHTTPRequestOperation *) multipleQueries:(NSArray*)queries withStrategy:(NSString*)strategy
+                                    success:(void(^)(ASAPIClient *client, NSArray *queries, NSString* strategy, NSDictionary *result))success
+                                    failure: (void(^)(ASAPIClient *client, NSArray *queries, NSString* strategy, NSString *errorMessage))failure
 {
     NSMutableArray *queriesTab =[[NSMutableArray alloc] initWithCapacity:[queries count]];
     int i = 0;
@@ -174,7 +174,7 @@ NSString *const Version = @"3.4.2";
     }
     NSString *path = [NSString stringWithFormat:@"/1/indexes/*/queries?strategy=%@", strategy];
     NSMutableDictionary *request = [NSMutableDictionary dictionaryWithObject:queriesTab forKey:@"requests"];
-    [self performHTTPQuery:path method:@"POST" body:request managers:self.searchOperationManagers index:0 timeout:self.searchTimeout success:^(id JSON) {
+    return [self performHTTPQuery:path method:@"POST" body:request managers:self.searchOperationManagers index:0 timeout:self.searchTimeout success:^(id JSON) {
         if (success != nil)
             success(self, queries, strategy, JSON);
     } failure:^(NSString *errorMessage) {
@@ -183,22 +183,24 @@ NSString *const Version = @"3.4.2";
     }];
 }
 
--(void) listIndexes:(void(^)(ASAPIClient *client, NSDictionary* result))success failure:(void(^)(ASAPIClient *client, NSString *errorMessage))failure
+-(AFHTTPRequestOperation *) listIndexes:(void(^)(ASAPIClient *client, NSDictionary* result))success
+                                failure:(void(^)(ASAPIClient *client, NSString *errorMessage))failure
 {
-    [self performHTTPQuery:@"/1/indexes" method:@"GET" body:nil managers:self.searchOperationManagers index:0 timeout:self.timeout success:^(id JSON) {
+    return [self performHTTPQuery:@"/1/indexes" method:@"GET" body:nil managers:self.searchOperationManagers index:0 timeout:self.timeout success:^(id JSON) {
         success(self, JSON);
     } failure:^(NSString *errorMessage) {
         failure(self, errorMessage);
     }];
 }
 
--(void) moveIndex:(NSString*)srcIndexName to:(NSString*)dstIndexName
-          success:(void(^)(ASAPIClient *client, NSString *srcIndexName, NSString *dstIndexName, NSDictionary *result))success
-          failure:(void(^)(ASAPIClient *client, NSString *srcIndexName, NSString *dstIndexName, NSString *errorMessage))failure
+-(AFHTTPRequestOperation *) moveIndex:(NSString*)srcIndexName
+                                   to:(NSString*)dstIndexName
+                              success:(void(^)(ASAPIClient *client, NSString *srcIndexName, NSString *dstIndexName, NSDictionary *result))success
+                              failure:(void(^)(ASAPIClient *client, NSString *srcIndexName, NSString *dstIndexName, NSString *errorMessage))failure
 {
     NSString *path = [NSString stringWithFormat:@"/1/indexes/%@/operation", [ASAPIClient urlEncode:srcIndexName]];
     NSDictionary *request = @{@"destination": dstIndexName, @"operation": @"move"};
-    [self performHTTPQuery:path method:@"POST" body:request managers:self.writeOperationManagers index:0 timeout:self.timeout success:^(id JSON) {
+    return [self performHTTPQuery:path method:@"POST" body:request managers:self.writeOperationManagers index:0 timeout:self.timeout success:^(id JSON) {
         if (success != nil)
             success(self, srcIndexName, dstIndexName, JSON);
     } failure:^(NSString *errorMessage) {
@@ -207,13 +209,14 @@ NSString *const Version = @"3.4.2";
     }];
 }
 
--(void) copyIndex:(NSString*)srcIndexName to:(NSString*)dstIndexName
-          success:(void(^)(ASAPIClient *client, NSString *srcIndexName, NSString *dstIndexName, NSDictionary *result))success
-          failure:(void(^)(ASAPIClient *client, NSString *srcIndexName, NSString *dstIndexName, NSString *errorMessage))failure
+-(AFHTTPRequestOperation *) copyIndex:(NSString*)srcIndexName
+                                   to:(NSString*)dstIndexName
+                              success:(void(^)(ASAPIClient *client, NSString *srcIndexName, NSString *dstIndexName, NSDictionary *result))success
+                              failure:(void(^)(ASAPIClient *client, NSString *srcIndexName, NSString *dstIndexName, NSString *errorMessage))failure
 {
     NSString *path = [NSString stringWithFormat:@"/1/indexes/%@/operation", [ASAPIClient urlEncode:srcIndexName]];
     NSDictionary *request = @{@"destination": dstIndexName, @"operation": @"copy"};
-    [self performHTTPQuery:path method:@"POST" body:request managers:self.writeOperationManagers index:0 timeout:self.timeout success:^(id JSON) {
+    return [self performHTTPQuery:path method:@"POST" body:request managers:self.writeOperationManagers index:0 timeout:self.timeout success:^(id JSON) {
         if (success != nil)
             success(self, srcIndexName, dstIndexName, JSON);
     } failure:^(NSString *errorMessage) {
@@ -222,47 +225,50 @@ NSString *const Version = @"3.4.2";
     }];
 }
 
--(void) getLogs:(void(^)(ASAPIClient *client, NSDictionary *result))success
-        failure:(void(^)(ASAPIClient *client, NSString *errorMessage))failure
+-(AFHTTPRequestOperation *) getLogs:(void(^)(ASAPIClient *client, NSDictionary *result))success
+                            failure:(void(^)(ASAPIClient *client, NSString *errorMessage))failure
 {
-    [self performHTTPQuery:@"/1/logs" method:@"GET" body:nil managers:self.writeOperationManagers index:0 timeout:self.timeout success:^(id JSON) {
+    return [self performHTTPQuery:@"/1/logs" method:@"GET" body:nil managers:self.writeOperationManagers index:0 timeout:self.timeout success:^(id JSON) {
         success(self, JSON);
     } failure:^(NSString *errorMessage) {
         failure(self, errorMessage);
     }];
 }
 
--(void) getLogsWithOffset:(NSUInteger)offset length:(NSUInteger)length
-                  success:(void(^)(ASAPIClient *client, NSUInteger offset, NSUInteger length, NSDictionary *result))success
-                  failure:(void(^)(ASAPIClient *client, NSUInteger offset, NSUInteger length, NSString *errorMessage))failure
+-(AFHTTPRequestOperation *) getLogsWithOffset:(NSUInteger)offset
+                                       length:(NSUInteger)length
+                                      success:(void(^)(ASAPIClient *client, NSUInteger offset, NSUInteger length, NSDictionary *result))success
+                                      failure:(void(^)(ASAPIClient *client, NSUInteger offset, NSUInteger length, NSString *errorMessage))failure
 {
     NSString *url = [NSString stringWithFormat:@"/1/logs?offset=%zd&length=%zd", offset, length];
-    [self performHTTPQuery:url method:@"GET" body:nil managers:self.writeOperationManagers index:0 timeout:self.timeout success:^(id JSON) {
+    return [self performHTTPQuery:url method:@"GET" body:nil managers:self.writeOperationManagers index:0 timeout:self.timeout success:^(id JSON) {
         success(self, offset, length, JSON);
     } failure:^(NSString *errorMessage) {
         failure(self, offset, length, errorMessage);
     }];
 }
 
--(void) getLogsWithType:(NSUInteger)offset length:(NSUInteger)length type:(NSString*)type
-                success:(void(^)(ASAPIClient *client, NSUInteger offset, NSUInteger length, NSString* type, NSDictionary *result))success
-                failure:(void(^)(ASAPIClient *client, NSUInteger offset, NSUInteger length, NSString* type, NSString *errorMessage))failure
+-(AFHTTPRequestOperation *) getLogsWithType:(NSUInteger)offset
+                                     length:(NSUInteger)length
+                                       type:(NSString*)type
+                                    success:(void(^)(ASAPIClient *client, NSUInteger offset, NSUInteger length, NSString* type, NSDictionary *result))success
+                                    failure:(void(^)(ASAPIClient *client, NSUInteger offset, NSUInteger length, NSString* type, NSString *errorMessage))failure
 {
     NSString *url = [NSString stringWithFormat:@"/1/logs?offset=%zd&length=%zd&type=%@", offset, length, type];
-    [self performHTTPQuery:url method:@"GET" body:nil managers:self.writeOperationManagers index:0 timeout:self.timeout success:^(id JSON) {
+    return [self performHTTPQuery:url method:@"GET" body:nil managers:self.writeOperationManagers index:0 timeout:self.timeout success:^(id JSON) {
         success(self, offset, length, type, JSON);
     } failure:^(NSString *errorMessage) {
         failure(self, offset, length, type, errorMessage);
     }];
 }
 
--(void) deleteIndex:(NSString*)indexName
-            success:(void(^)(ASAPIClient *client, NSString *indexName, NSDictionary *result))success
-            failure:(void(^)(ASAPIClient *client, NSString *indexName, NSString *errorMessage))failure
+-(AFHTTPRequestOperation *) deleteIndex:(NSString*)indexName
+                                success:(void(^)(ASAPIClient *client, NSString *indexName, NSDictionary *result))success
+                                failure:(void(^)(ASAPIClient *client, NSString *indexName, NSString *errorMessage))failure
 {
     NSString *path = [NSString stringWithFormat:@"/1/indexes/%@", [ASAPIClient urlEncode:indexName]];
     
-    [self performHTTPQuery:path method:@"DELETE" body:nil managers:self.writeOperationManagers index:0 timeout:self.timeout success:^(id JSON) {
+    return [self performHTTPQuery:path method:@"DELETE" body:nil managers:self.writeOperationManagers index:0 timeout:self.timeout success:^(id JSON) {
         if (success != nil)
             success(self, indexName, JSON);
     } failure:^(NSString *errorMessage) {
@@ -271,21 +277,22 @@ NSString *const Version = @"3.4.2";
     }];
 }
 
--(void) listUserKeys:(void(^)(ASAPIClient *client, NSDictionary* result))success
-                     failure:(void(^)(ASAPIClient *client, NSString *errorMessage))failure
+-(AFHTTPRequestOperation *) listUserKeys:(void(^)(ASAPIClient *client, NSDictionary* result))success
+                                 failure:(void(^)(ASAPIClient *client, NSString *errorMessage))failure
 {
-    [self performHTTPQuery:@"/1/keys" method:@"GET" body:nil managers:self.searchOperationManagers index:0 timeout:self.timeout success:^(id JSON) {
+    return [self performHTTPQuery:@"/1/keys" method:@"GET" body:nil managers:self.searchOperationManagers index:0 timeout:self.timeout success:^(id JSON) {
         success(self, JSON);
     } failure:^(NSString *errorMessage) {
         failure(self, errorMessage);
     }];
 }
 
--(void) getUserKeyACL:(NSString*)key success:(void(^)(ASAPIClient *client, NSString *key, NSDictionary *result))success
-                      failure:(void(^)(ASAPIClient *client, NSString *key, NSString *errorMessage))failure
+-(AFHTTPRequestOperation *) getUserKeyACL:(NSString*)key
+                                  success:(void(^)(ASAPIClient *client, NSString *key, NSDictionary *result))success
+                                  failure:(void(^)(ASAPIClient *client, NSString *key, NSString *errorMessage))failure
 {
     NSString *path = [NSString stringWithFormat:@"/1/keys/%@", key];
-    [self performHTTPQuery:path method:@"GET" body:nil managers:self.searchOperationManagers index:0 timeout:self.timeout success:^(id JSON) {
+    return [self performHTTPQuery:path method:@"GET" body:nil managers:self.searchOperationManagers index:0 timeout:self.timeout success:^(id JSON) {
         if (success != nil)
             success(self, key, JSON);
     } failure:^(NSString *errorMessage) {
@@ -294,11 +301,12 @@ NSString *const Version = @"3.4.2";
     }];
 }
 
--(void) deleteUserKey:(NSString*)key success:(void(^)(ASAPIClient *client, NSString *key, NSDictionary *result))success
-                       failure:(void(^)(ASAPIClient *client, NSString *key, NSString *errorMessage))failure
+-(AFHTTPRequestOperation *) deleteUserKey:(NSString*)key
+                                  success:(void(^)(ASAPIClient *client, NSString *key, NSDictionary *result))success
+                                  failure:(void(^)(ASAPIClient *client, NSString *key, NSString *errorMessage))failure
 {
     NSString *path = [NSString stringWithFormat:@"/1/keys/%@", key];
-    [self performHTTPQuery:path method:@"DELETE" body:nil managers:self.writeOperationManagers index:0 timeout:self.timeout success:^(id JSON) {
+    return [self performHTTPQuery:path method:@"DELETE" body:nil managers:self.writeOperationManagers index:0 timeout:self.timeout success:^(id JSON) {
         if (success != nil)
             success(self, key, JSON);
     } failure:^(NSString *errorMessage) {
@@ -307,13 +315,13 @@ NSString *const Version = @"3.4.2";
     }];
 }
 
--(void) addUserKey:(NSArray*)acls
-           success:(void(^)(ASAPIClient *client, NSArray* acls, NSDictionary *result))success
-           failure:(void(^)(ASAPIClient *client, NSArray* acls, NSString *errorMessage))failure
+-(AFHTTPRequestOperation *) addUserKey:(NSArray*)acls
+                               success:(void(^)(ASAPIClient *client, NSArray* acls, NSDictionary *result))success
+                               failure:(void(^)(ASAPIClient *client, NSArray* acls, NSString *errorMessage))failure
 {
     NSDictionary *params = [NSMutableDictionary dictionaryWithObject:acls forKey:@"acl"];
     
-    [self addUserKey:acls withParams:params success:^(ASAPIClient *client, NSArray* acls, NSDictionary* params, NSDictionary *result) {
+    return [self addUserKey:acls withParams:params success:^(ASAPIClient *client, NSArray* acls, NSDictionary* params, NSDictionary *result) {
         if (success != nil)
             success(client, acls, result);
     } failure:^(ASAPIClient *client, NSArray* acls, NSDictionary* params, NSString *errorMessage) {
@@ -322,12 +330,13 @@ NSString *const Version = @"3.4.2";
     }];
 }
 
--(void) addUserKey:(NSArray*)acls withParams:(NSDictionary*)params
-           success:(void(^)(ASAPIClient *client, NSArray* acls, NSDictionary* params, NSDictionary *result))success
-           failure:(void(^)(ASAPIClient *client, NSArray* acls, NSDictionary* params, NSString *errorMessage))failure
+-(AFHTTPRequestOperation *) addUserKey:(NSArray*)acls
+                            withParams:(NSDictionary*)params
+                               success:(void(^)(ASAPIClient *client, NSArray* acls, NSDictionary* params, NSDictionary *result))success
+                               failure:(void(^)(ASAPIClient *client, NSArray* acls, NSDictionary* params, NSString *errorMessage))failure
 {
     [params setValue:acls forKey:@"acl"];
-    [self performHTTPQuery:@"/1/keys" method:@"POST" body:params managers:self.writeOperationManagers index:0 timeout:self.timeout success:^(id JSON) {
+    return [self performHTTPQuery:@"/1/keys" method:@"POST" body:params managers:self.writeOperationManagers index:0 timeout:self.timeout success:^(id JSON) {
         if (success != nil)
             success(self, acls, params, JSON);
     } failure:^(NSString *errorMessage) {
@@ -336,16 +345,19 @@ NSString *const Version = @"3.4.2";
     }];
 }
 
--(void) addUserKey:(NSArray*)acls withValidity:(NSUInteger)validity maxQueriesPerIPPerHour:(NSUInteger)maxQueriesPerIPPerHour maxHitsPerQuery:(NSUInteger)maxHitsPerQuery
-           success:(void(^)(ASAPIClient *client, NSArray *acls, NSDictionary *result))success
-           failure:(void(^)(ASAPIClient *client, NSArray *acls, NSString *errorMessage))failure
+-(AFHTTPRequestOperation *) addUserKey:(NSArray*)acls
+                          withValidity:(NSUInteger)validity
+                maxQueriesPerIPPerHour:(NSUInteger)maxQueriesPerIPPerHour
+                       maxHitsPerQuery:(NSUInteger)maxHitsPerQuery
+                               success:(void(^)(ASAPIClient *client, NSArray *acls, NSDictionary *result))success
+                               failure:(void(^)(ASAPIClient *client, NSArray *acls, NSString *errorMessage))failure
 {
-    NSMutableDictionary *dict = [NSMutableDictionary dictionaryWithObjectsAndKeys:acls, @"acl", 
-                                @(validity), @"validity", 
-                                @(maxQueriesPerIPPerHour), @"maxQueriesPerIPPerHour", 
-                                @(maxHitsPerQuery), @"maxHitsPerQuery", 
-                                nil];
-    [self addUserKey:acls withParams:dict success:^(ASAPIClient *client, NSArray* acls, NSDictionary* params, NSDictionary *result) {
+    NSMutableDictionary *dict = [NSMutableDictionary dictionaryWithObjectsAndKeys:acls, @"acl",
+                                 @(validity), @"validity",
+                                 @(maxQueriesPerIPPerHour), @"maxQueriesPerIPPerHour",
+                                 @(maxHitsPerQuery), @"maxHitsPerQuery",
+                                 nil];
+    return [self addUserKey:acls withParams:dict success:^(ASAPIClient *client, NSArray* acls, NSDictionary* params, NSDictionary *result) {
         if (success != nil)
             success(client, acls, result);
     } failure:^(ASAPIClient *client, NSArray* acls, NSDictionary* params, NSString *errorMessage) {
@@ -354,16 +366,20 @@ NSString *const Version = @"3.4.2";
     }];
 }
 
--(void) addUserKey:(NSArray*)acls withIndexes:(NSArray*)indexes withValidity:(NSUInteger)validity maxQueriesPerIPPerHour:(NSUInteger)maxQueriesPerIPPerHour maxHitsPerQuery:(NSUInteger)maxHitsPerQuery
-           success:(void(^)(ASAPIClient *client, NSArray *acls, NSArray *indexes, NSDictionary *result))success
-           failure:(void(^)(ASAPIClient *client, NSArray *acls, NSArray *indexes, NSString *errorMessage))failure
+-(AFHTTPRequestOperation *) addUserKey:(NSArray*)acls
+                           withIndexes:(NSArray*)indexes
+                          withValidity:(NSUInteger)validity
+                maxQueriesPerIPPerHour:(NSUInteger)maxQueriesPerIPPerHour
+                       maxHitsPerQuery:(NSUInteger)maxHitsPerQuery
+                               success:(void(^)(ASAPIClient *client, NSArray *acls, NSArray *indexes, NSDictionary *result))success
+                               failure:(void(^)(ASAPIClient *client, NSArray *acls, NSArray *indexes, NSString *errorMessage))failure
 {
     NSMutableDictionary *dict = [NSMutableDictionary dictionaryWithObjectsAndKeys:acls, @"acl", indexes, @"indexes",
                                  @(validity), @"validity",
                                  @(maxQueriesPerIPPerHour), @"maxQueriesPerIPPerHour",
                                  @(maxHitsPerQuery), @"maxHitsPerQuery",
                                  nil];
-    [self addUserKey:acls withParams:dict success:^(ASAPIClient *client, NSArray* acls, NSDictionary* params, NSDictionary *result) {
+    return [self addUserKey:acls withParams:dict success:^(ASAPIClient *client, NSArray* acls, NSDictionary* params, NSDictionary *result) {
         if (success != nil)
             success(client, acls, indexes, result);
     } failure:^(ASAPIClient *client, NSArray* acls, NSDictionary* params, NSString *errorMessage) {
@@ -372,11 +388,13 @@ NSString *const Version = @"3.4.2";
     }];
 }
 
--(void) updateUserKey:(NSString*)key withParams:(NSDictionary*)params success:(void(^)(ASAPIClient *client, NSString *key, NSDictionary *params, NSDictionary *result))success
-              failure:(void(^)(ASAPIClient *client, NSString *key, NSDictionary *params, NSString *errorMessage))failure
+-(AFHTTPRequestOperation *) updateUserKey:(NSString*)key
+                               withParams:(NSDictionary*)params
+                                  success:(void(^)(ASAPIClient *client, NSString *key, NSDictionary *params, NSDictionary *result))success
+                                  failure:(void(^)(ASAPIClient *client, NSString *key, NSDictionary *params, NSString *errorMessage))failure
 {
     NSString *path = [NSString stringWithFormat:@"/1/keys/%@", key];
-    [self performHTTPQuery:path method:@"PUT" body:params managers:self.writeOperationManagers index:0 timeout:self.timeout success:^(id JSON) {
+    return [self performHTTPQuery:path method:@"PUT" body:params managers:self.writeOperationManagers index:0 timeout:self.timeout success:^(id JSON) {
         if (success != nil)
             success(self, key, params, JSON);
     } failure:^(NSString *errorMessage) {
@@ -385,11 +403,13 @@ NSString *const Version = @"3.4.2";
     }];
 }
 
--(void) updateUserKey:(NSString*)key withACL:(NSArray*)acls success:(void(^)(ASAPIClient *client, NSString *key, NSArray *acls, NSDictionary *result))success
-           failure:(void(^)(ASAPIClient *client, NSString *key, NSArray *acls, NSString *errorMessage))failure
+-(AFHTTPRequestOperation *) updateUserKey:(NSString*)key
+                                  withACL:(NSArray*)acls
+                                  success:(void(^)(ASAPIClient *client, NSString *key, NSArray *acls, NSDictionary *result))success
+                                  failure:(void(^)(ASAPIClient *client, NSString *key, NSArray *acls, NSString *errorMessage))failure
 {
     NSMutableDictionary *dict = [NSMutableDictionary dictionaryWithObject:acls forKey:@"acl"];
-    [self updateUserKey:key withParams:dict success:^(ASAPIClient *client, NSString *key, NSDictionary *params, NSDictionary *result) {
+    return [self updateUserKey:key withParams:dict success:^(ASAPIClient *client, NSString *key, NSDictionary *params, NSDictionary *result) {
         if (success != nil)
             success(client, key, acls, result);
     } failure:^(ASAPIClient *client, NSString *key, NSDictionary *params, NSString *errorMessage) {
@@ -398,16 +418,20 @@ NSString *const Version = @"3.4.2";
     }];
 }
 
--(void) updateUserKey:(NSString*)key withACL:(NSArray*)acls withValidity:(NSUInteger)validity maxQueriesPerIPPerHour:(NSUInteger)maxQueriesPerIPPerHour maxHitsPerQuery:(NSUInteger)maxHitsPerQuery
-           success:(void(^)(ASAPIClient *client, NSString *key, NSArray *acls, NSDictionary *result))success
-           failure:(void(^)(ASAPIClient *client, NSString *key, NSArray *acls, NSString *errorMessage))failure
+-(AFHTTPRequestOperation *) updateUserKey:(NSString*)key
+                                  withACL:(NSArray*)acls
+                             withValidity:(NSUInteger)validity
+                   maxQueriesPerIPPerHour:(NSUInteger)maxQueriesPerIPPerHour
+                          maxHitsPerQuery:(NSUInteger)maxHitsPerQuery
+                                  success:(void(^)(ASAPIClient *client, NSString *key, NSArray *acls, NSDictionary *result))success
+                                  failure:(void(^)(ASAPIClient *client, NSString *key, NSArray *acls, NSString *errorMessage))failure
 {
     NSMutableDictionary *dict = [NSMutableDictionary dictionaryWithObjectsAndKeys:acls, @"acl",
                                  @(validity), @"validity",
                                  @(maxQueriesPerIPPerHour), @"maxQueriesPerIPPerHour",
                                  @(maxHitsPerQuery), @"maxHitsPerQuery",
                                  nil];
-    [self updateUserKey:key withParams:dict success:^(ASAPIClient *client, NSString *key, NSDictionary *params, NSDictionary *result) {
+    return [self updateUserKey:key withParams:dict success:^(ASAPIClient *client, NSString *key, NSDictionary *params, NSDictionary *result) {
         if (success != nil)
             success(client, key, acls, result);
     } failure:^(ASAPIClient *client, NSString *key, NSDictionary *params, NSString *errorMessage) {
@@ -416,16 +440,21 @@ NSString *const Version = @"3.4.2";
     }];
 }
 
--(void) updateUserKey:(NSString*)key withACL:(NSArray*)acls withIndexes:(NSArray*)indexes withValidity:(NSUInteger)validity maxQueriesPerIPPerHour:(NSUInteger)maxQueriesPerIPPerHour maxHitsPerQuery:(NSUInteger)maxHitsPerQuery
-           success:(void(^)(ASAPIClient *client, NSString *key, NSArray *acls, NSArray *indexes, NSDictionary *result))success
-           failure:(void(^)(ASAPIClient *client, NSString *key, NSArray *acls, NSArray *indexes, NSString *errorMessage))failure
+-(AFHTTPRequestOperation *) updateUserKey:(NSString*)key
+                                  withACL:(NSArray*)acls
+                              withIndexes:(NSArray*)indexes
+                             withValidity:(NSUInteger)validity
+                   maxQueriesPerIPPerHour:(NSUInteger)maxQueriesPerIPPerHour
+                          maxHitsPerQuery:(NSUInteger)maxHitsPerQuery
+                                  success:(void(^)(ASAPIClient *client, NSString *key, NSArray *acls, NSArray *indexes, NSDictionary *result))success
+                                  failure:(void(^)(ASAPIClient *client, NSString *key, NSArray *acls, NSArray *indexes, NSString *errorMessage))failure
 {
     NSMutableDictionary *dict = [NSMutableDictionary dictionaryWithObjectsAndKeys:acls, @"acl", indexes, @"indexes",
                                  @(validity), @"validity",
                                  @(maxQueriesPerIPPerHour), @"maxQueriesPerIPPerHour",
                                  @(maxHitsPerQuery), @"maxHitsPerQuery",
                                  nil];
-    [self updateUserKey:key withParams:dict success:^(ASAPIClient *client, NSString *key, NSDictionary *params, NSDictionary *result) {
+    return [self updateUserKey:key withParams:dict success:^(ASAPIClient *client, NSString *key, NSDictionary *params, NSDictionary *result) {
         if (success != nil)
             success(client, key, acls, indexes, result);
     } failure:^(ASAPIClient *client, NSString *key, NSDictionary *params, NSString *errorMessage) {

--- a/src/ASRemoteIndex.h
+++ b/src/ASRemoteIndex.h
@@ -24,6 +24,7 @@
 #import <Foundation/Foundation.h>
 #import "ASQuery.h"
 
+@class AFHTTPRequestOperation;
 @class ASAPIClient;
 
 /**
@@ -49,9 +50,9 @@
  * @param content contains the object to add inside the index.
  *  The object is represented by an associative array
  */
--(void) addObject:(NSDictionary*)object
-          success:(void(^)(ASRemoteIndex *index, NSDictionary *object, NSDictionary *result))success
-          failure:(void(^)(ASRemoteIndex *index, NSDictionary *object, NSString *errorMessage))failure;
+-(AFHTTPRequestOperation *) addObject:(NSDictionary*)object
+                              success:(void(^)(ASRemoteIndex *index, NSDictionary *object, NSDictionary *result))success
+                              failure:(void(^)(ASRemoteIndex *index, NSDictionary *object, NSString *errorMessage))failure;
 
 /**
  * Add an object in this index
@@ -61,36 +62,37 @@
  * @param objectID an objectID you want to attribute to this object
  * (if the attribute already exist the old object will be overwrite)
  */
--(void) addObject:(NSDictionary*)object withObjectID:(NSString*)objectID
-           success:(void(^)(ASRemoteIndex *index, NSDictionary *object, NSString *objectID, NSDictionary *result))success
-           failure:(void(^)(ASRemoteIndex *index, NSDictionary *object, NSString *objectID, NSString *errorMessage))failure;
+-(AFHTTPRequestOperation *) addObject:(NSDictionary*)object
+                         withObjectID:(NSString*)objectID
+                              success:(void(^)(ASRemoteIndex *index, NSDictionary *object, NSString *objectID, NSDictionary *result))success
+                              failure:(void(^)(ASRemoteIndex *index, NSDictionary *object, NSString *objectID, NSString *errorMessage))failure;
 
 /**
  * Add several objects
  *
  * @param objects contains an array of objects to add (NSArray of NSDictionary object).
  */
--(void) addObjects:(NSArray*)objects
-           success:(void(^)(ASRemoteIndex *index, NSArray *objects, NSDictionary *result))success
-           failure:(void(^)(ASRemoteIndex *index, NSArray *objects, NSString *errorMessage))failure;
+-(AFHTTPRequestOperation *) addObjects:(NSArray*)objects
+                               success:(void(^)(ASRemoteIndex *index, NSArray *objects, NSDictionary *result))success
+                               failure:(void(^)(ASRemoteIndex *index, NSArray *objects, NSString *errorMessage))failure;
 
 /**
  * Delete several objects
  *
  * @param objects contains an array of objectID to delete (NSArray of NSString object).
  */
--(void) deleteObjects:(NSArray*)objects
-           success:(void(^)(ASRemoteIndex *index, NSArray *objects, NSDictionary *result))success
-           failure:(void(^)(ASRemoteIndex *index, NSArray *objects, NSString *errorMessage))failure;
+-(AFHTTPRequestOperation *) deleteObjects:(NSArray*)objects
+                                  success:(void(^)(ASRemoteIndex *index, NSArray *objects, NSDictionary *result))success
+                                  failure:(void(^)(ASRemoteIndex *index, NSArray *objects, NSString *errorMessage))failure;
 
 /**
  * Get an object from this index
  *
  * @param objectID the unique identifier of the object to retrieve
  */
--(void) getObject:(NSString*)objectID
-          success:(void(^)(ASRemoteIndex *index, NSString *objectID, NSDictionary *result))success
-          failure:(void(^)(ASRemoteIndex *index, NSString *objectID, NSString *errorMessage))failure;
+-(AFHTTPRequestOperation *) getObject:(NSString*)objectID
+                              success:(void(^)(ASRemoteIndex *index, NSString *objectID, NSDictionary *result))success
+                              failure:(void(^)(ASRemoteIndex *index, NSString *objectID, NSString *errorMessage))failure;
 
 /**
  * Get an object from this index
@@ -98,18 +100,19 @@
  * @param objectID the unique identifier of the object to retrieve
  * @param attributesToRetrieve, contains the list of attributes to retrieve as a string separated by ","
  */
--(void) getObject:(NSString*)objectID attributesToRetrieve:(NSArray*)attributes
-          success:(void(^)(ASRemoteIndex *index, NSString *objectID, NSArray *attributesToRetrieve, NSDictionary *result))success
-          failure:(void(^)(ASRemoteIndex *index, NSString *objectID, NSArray *attributesToRetrieve, NSString *errorMessage))failure;
+-(AFHTTPRequestOperation *) getObject:(NSString*)objectID
+                 attributesToRetrieve:(NSArray*)attributes
+                              success:(void(^)(ASRemoteIndex *index, NSString *objectID, NSArray *attributesToRetrieve, NSDictionary *result))success
+                              failure:(void(^)(ASRemoteIndex *index, NSString *objectID, NSArray *attributesToRetrieve, NSString *errorMessage))failure;
 
 /**
  * Get several objects from this index
  *
  * @param objectIDs the array of unique identifier of objects to retrieve
  */
--(void) getObjects:(NSArray*)objectIDs
-           success:(void(^)(ASRemoteIndex *index, NSArray *objectIDs, NSDictionary *result))success
-           failure:(void(^)(ASRemoteIndex *index, NSArray *objectIDs, NSString *errorMessage))failure;
+-(AFHTTPRequestOperation *) getObjects:(NSArray*)objectIDs
+                               success:(void(^)(ASRemoteIndex *index, NSArray *objectIDs, NSDictionary *result))success
+                               failure:(void(^)(ASRemoteIndex *index, NSArray *objectIDs, NSString *errorMessage))failure;
 
 /**
  * Update partially an object (only update attributes passed in argument)
@@ -117,18 +120,19 @@
  * @param partialObject contains the object attributes to override, the
  *  object must contains an objectID attribute
  */
--(void) partialUpdateObject:(NSDictionary*)partialObject objectID:(NSString*)objectID
-                    success:(void(^)(ASRemoteIndex *index, NSDictionary *partialObject, NSString *objectID, NSDictionary *result))success
-                    failure:(void(^)(ASRemoteIndex *index, NSDictionary *partialObject, NSString *objectID, NSString *errorMessage))failure;
+-(AFHTTPRequestOperation *) partialUpdateObject:(NSDictionary*)partialObject
+                                       objectID:(NSString*)objectID
+                                        success:(void(^)(ASRemoteIndex *index, NSDictionary *partialObject, NSString *objectID, NSDictionary *result))success
+                                        failure:(void(^)(ASRemoteIndex *index, NSDictionary *partialObject, NSString *objectID, NSString *errorMessage))failure;
 
 /**
  * Partially override the content of several objects
  *
  * @param objects contains an array of NSDictionary to update (each NSDictionary must contains an objectID attribute)
  */
--(void) partialUpdateObjects:(NSArray*)objects
-            success:(void(^)(ASRemoteIndex *index, NSArray *objects, NSDictionary *result))success
-            failure:(void(^)(ASRemoteIndex *index, NSArray *objects, NSString *errorMessage))failure;
+-(AFHTTPRequestOperation *) partialUpdateObjects:(NSArray*)objects
+                                         success:(void(^)(ASRemoteIndex *index, NSArray *objects, NSDictionary *result))success
+                                         failure:(void(^)(ASRemoteIndex *index, NSArray *objects, NSString *errorMessage))failure;
 
 
 /**
@@ -136,34 +140,35 @@
  *
  * @param object contains the object to save
  */
--(void) saveObject:(NSDictionary*)object objectID:(NSString*)objectID
-           success:(void(^)(ASRemoteIndex *index, NSDictionary *object, NSString *objectID, NSDictionary *result))success
-           failure:(void(^)(ASRemoteIndex *index, NSDictionary *object, NSString *objectID, NSString *errorMessage))failure;
+-(AFHTTPRequestOperation *) saveObject:(NSDictionary*)object
+                              objectID:(NSString*)objectID
+                               success:(void(^)(ASRemoteIndex *index, NSDictionary *object, NSString *objectID, NSDictionary *result))success
+                               failure:(void(^)(ASRemoteIndex *index, NSDictionary *object, NSString *objectID, NSString *errorMessage))failure;
 
 /**
  * Override the content of several objects
  *
  * @param objects contains an array of NSDictionary to update (each NSDictionary must contains an objectID attribute)
  */
--(void) saveObjects:(NSArray*)objects
-            success:(void(^)(ASRemoteIndex *index, NSArray *objects, NSDictionary *result))success
-            failure:(void(^)(ASRemoteIndex *index, NSArray *objects, NSString *errorMessage))failure;
+-(AFHTTPRequestOperation *) saveObjects:(NSArray*)objects
+                                success:(void(^)(ASRemoteIndex *index, NSArray *objects, NSDictionary *result))success
+                                failure:(void(^)(ASRemoteIndex *index, NSArray *objects, NSString *errorMessage))failure;
 
 /**
  * Delete an object from the index
  *
  * @param objectID the unique identifier of object to delete
  */
--(void) deleteObject:(NSString*)objectID
-             success:(void(^)(ASRemoteIndex *index, NSString *objectID, NSDictionary *result))success
-             failure:(void(^)(ASRemoteIndex *index, NSString *objectID, NSString *errorMessage))failure;
+-(AFHTTPRequestOperation *) deleteObject:(NSString*)objectID
+                                 success:(void(^)(ASRemoteIndex *index, NSString *objectID, NSDictionary *result))success
+                                 failure:(void(^)(ASRemoteIndex *index, NSString *objectID, NSString *errorMessage))failure;
 
 /**
  * Search inside the index
  */
--(void) search:(ASQuery*)query
-       success:(void(^)(ASRemoteIndex *index, ASQuery *query, NSDictionary *result))success
-       failure:(void(^)(ASRemoteIndex *index, ASQuery *query, NSString *errorMessage))failure;
+-(AFHTTPRequestOperation *) search:(ASQuery*)query
+                           success:(void(^)(ASRemoteIndex *index, ASQuery *query, NSDictionary *result))success
+                           failure:(void(^)(ASRemoteIndex *index, ASQuery *query, NSString *errorMessage))failure;
 
 /**
  * Wait the publication of a task on the server.
@@ -171,16 +176,16 @@
  *
  * @param taskID the id of the task returned by server
  */
--(void) waitTask:(NSString*)taskID
-         success:(void(^)(ASRemoteIndex *index, NSString *taskID, NSDictionary *result))success
-         failure:(void(^)(ASRemoteIndex *index, NSString *taskID, NSString *errorMessage))failure;
+-(AFHTTPRequestOperation *) waitTask:(NSString*)taskID
+                             success:(void(^)(ASRemoteIndex *index, NSString *taskID, NSDictionary *result))success
+                             failure:(void(^)(ASRemoteIndex *index, NSString *taskID, NSString *errorMessage))failure;
 
 
 /**
  * Get settings of this index
  */
--(void) getSettings:(void(^)(ASRemoteIndex *index, NSDictionary *result))success
-                    failure:(void(^)(ASRemoteIndex *index, NSString *errorMessage))failure;
+-(AFHTTPRequestOperation *) getSettings:(void(^)(ASRemoteIndex *index, NSDictionary *result))success
+                                failure:(void(^)(ASRemoteIndex *index, NSString *errorMessage))failure;
 
 /**
  * Set settings for this index
@@ -189,25 +194,25 @@
  * - minWordSizefor1Typo: (integer) the minimum number of characters to accept one typo (default = 3).
  * - minWordSizefor2Typos: (integer) the minimum number of characters to accept two typos (default = 7).
  * - hitsPerPage: (integer) the number of hits per page (default = 10).
- * - attributesToRetrieve: (array of strings) default list of attributes to retrieve in objects. 
+ * - attributesToRetrieve: (array of strings) default list of attributes to retrieve in objects.
  *   If set to null, all attributes are retrieved.
- * - attributesToHighlight: (array of strings) default list of attributes to highlight. 
+ * - attributesToHighlight: (array of strings) default list of attributes to highlight.
  *   If set to null, all indexed attributes are highlighted.
  * - attributesToSnippet**: (array of strings) default list of attributes to snippet alongside the number of words to return (syntax is attributeName:nbWords).
  *   By default no snippet is computed. If set to null, no snippet is computed.
  * - attributesToIndex: (array of strings) the list of fields you want to index.
  *   If set to null, all textual and numerical attributes of your objects are indexed, but you should update it to get optimal results.
  *   This parameter has two important uses:
- *     - Limit the attributes to index: For example if you store a binary image in base64, you want to store it and be able to 
+ *     - Limit the attributes to index: For example if you store a binary image in base64, you want to store it and be able to
  *       retrieve it but you don't want to search in the base64 string.
- *     - Control part of the ranking*: (see the ranking parameter for full explanation) Matches in attributes at the beginning of 
- *       the list will be considered more important than matches in attributes further down the list. 
- *       In one attribute, matching text at the beginning of the attribute will be considered more important than text after, you can disable 
+ *     - Control part of the ranking*: (see the ranking parameter for full explanation) Matches in attributes at the beginning of
+ *       the list will be considered more important than matches in attributes further down the list.
+ *       In one attribute, matching text at the beginning of the attribute will be considered more important than text after, you can disable
  *       this behavior if you add your attribute inside `unordered(AttributeName)`, for example attributesToIndex: ["title", "unordered(text)"].
- * - attributesForFaceting: (array of strings) The list of fields you want to use for faceting. 
+ * - attributesForFaceting: (array of strings) The list of fields you want to use for faceting.
  *   All strings in the attribute selected for faceting are extracted and added as a facet. If set to null, no attribute is used for faceting.
  * - ranking: (array of strings) controls the way results are sorted.
- *   We have six available criteria: 
+ *   We have six available criteria:
  *    - typo: sort according to number of typos,
  *    - geo: sort according to decreassing distance when performing a geo-location based search,
  *    - proximity: sort according to the proximity of query words in hits,
@@ -217,7 +222,7 @@
  *   The standard order is ["typo", "geo", "proximity", "attribute", "exact", "custom"]
  * - customRanking: (array of strings) lets you specify part of the ranking.
  *   The syntax of this condition is an array of strings containing attributes prefixed by asc (ascending order) or desc (descending order) operator.
- *   For example `"customRanking" => ["desc(population)", "asc(name)"]`  
+ *   For example `"customRanking" => ["desc(population)", "asc(name)"]`
  * - queryType: Select how the query words are interpreted, it can be one of the following value:
  *   - prefixAll: all query words are interpreted as prefixes,
  *   - prefixLast: only the last word is interpreted as a prefix (default behavior),
@@ -226,35 +231,35 @@
  * - highlightPostTag: (string) Specify the string that is inserted after the highlighted parts in the query result (default to "</em>").
  * - optionalWords: (array of strings) Specify a list of words that should be considered as optional when found in the query.
  */
--(void) setSettings:(NSDictionary*)settings
-            success:(void(^)(ASRemoteIndex *index, NSDictionary *settings, NSDictionary *result))success
-            failure:(void(^)(ASRemoteIndex *index, NSDictionary *settings, NSString *errorMessage))failure;
+-(AFHTTPRequestOperation *) setSettings:(NSDictionary*)settings
+                                success:(void(^)(ASRemoteIndex *index, NSDictionary *settings, NSDictionary *result))success
+                                failure:(void(^)(ASRemoteIndex *index, NSDictionary *settings, NSString *errorMessage))failure;
 
 /**
  * Delete the index content without removing settings and index specific API keys.
  */
--(void) clearIndex:(void(^)(ASRemoteIndex *index, NSDictionary *result))success
-            failure:(void(^)(ASRemoteIndex *index, NSString *errorMessage))failure;
+-(AFHTTPRequestOperation *) clearIndex:(void(^)(ASRemoteIndex *index, NSDictionary *result))success
+                               failure:(void(^)(ASRemoteIndex *index, NSString *errorMessage))failure;
 
 /**
  * List all existing user keys associated to this index
  */
--(void) listUserKeys:(void(^)(ASRemoteIndex *index, NSDictionary *result))success
-            failure:(void(^)(ASRemoteIndex *index, NSString *errorMessage))failure;
+-(AFHTTPRequestOperation *) listUserKeys:(void(^)(ASRemoteIndex *index, NSDictionary *result))success
+                                 failure:(void(^)(ASRemoteIndex *index, NSString *errorMessage))failure;
 
 /**
  * Get ACL of a user key associated to this index
  */
--(void) getUserKeyACL:(NSString*)key
-            success:(void(^)(ASRemoteIndex *index, NSString *key, NSDictionary *result))success
-            failure:(void(^)(ASRemoteIndex *index, NSString *key, NSString *errorMessage))failure;
+-(AFHTTPRequestOperation *) getUserKeyACL:(NSString*)key
+                                  success:(void(^)(ASRemoteIndex *index, NSString *key, NSDictionary *result))success
+                                  failure:(void(^)(ASRemoteIndex *index, NSString *key, NSString *errorMessage))failure;
 
 /**
  * Delete an existing user key associated to this index
  */
--(void) deleteUserKey:(NSString*)key
-              success:(void(^)(ASRemoteIndex *index, NSString *key, NSDictionary *result))success
-              failure:(void(^)(ASRemoteIndex *index, NSString *key, NSString *errorMessage))failure;
+-(AFHTTPRequestOperation *) deleteUserKey:(NSString*)key
+                                  success:(void(^)(ASRemoteIndex *index, NSString *key, NSDictionary *result))success
+                                  failure:(void(^)(ASRemoteIndex *index, NSString *key, NSString *errorMessage))failure;
 
 /**
  * Create a new user key associated to this index
@@ -268,9 +273,9 @@
  *   - settings : allows to get index settings (https only)
  *   - editSettings : allows to change index settings (https only)
  */
--(void) addUserKey:(NSArray*)acls
-           success:(void(^)(ASRemoteIndex *index, NSArray *acls, NSDictionary *result))success
-           failure:(void(^)(ASRemoteIndex *index, NSArray *acls, NSString *errorMessage))failure;
+-(AFHTTPRequestOperation *) addUserKey:(NSArray*)acls
+                               success:(void(^)(ASRemoteIndex *index, NSArray *acls, NSDictionary *result))success
+                               failure:(void(^)(ASRemoteIndex *index, NSArray *acls, NSString *errorMessage))failure;
 
 /**
  * Create a new user key associated to this index
@@ -294,9 +299,10 @@
  *   - queryParameters: string
  *   - maxQueriesPerIPPerHour: integer
  */
--(void) addUserKey:(NSArray*)acls withParams:(NSDictionary*)params
-           success:(void(^)(ASRemoteIndex *index, NSArray* acls, NSDictionary *params, NSDictionary *result))success
-           failure:(void(^)(ASRemoteIndex *index, NSArray* acls, NSDictionary *params, NSString *errorMessage))failure;
+-(AFHTTPRequestOperation *) addUserKey:(NSArray*)acls
+                            withParams:(NSDictionary*)params
+                               success:(void(^)(ASRemoteIndex *index, NSArray* acls, NSDictionary *params, NSDictionary *result))success
+                               failure:(void(^)(ASRemoteIndex *index, NSArray* acls, NSDictionary *params, NSString *errorMessage))failure;
 
 
 /**
@@ -312,11 +318,14 @@
  *   - editSettings : allows to change index settings (https only)
  * @param validity the number of seconds after which the key will be automatically removed (0 means no time limit for this key)
  * @param maxQueriesPerIPPerHour Specify the maximum number of API calls allowed from an IP address per hour.  Defaults to 0 (no rate limit).
- * @param maxHitsPerQuery Specify the maximum number of hits this API key can retrieve in one call. Defaults to 0 (unlimited) 
+ * @param maxHitsPerQuery Specify the maximum number of hits this API key can retrieve in one call. Defaults to 0 (unlimited)
  */
--(void) addUserKey:(NSArray*)acls withValidity:(NSUInteger)validity maxQueriesPerIPPerHour:(NSUInteger)maxQueriesPerIPPerHour maxHitsPerQuery:(NSUInteger)maxHitsPerQuery
-           success:(void(^)(ASRemoteIndex *index, NSArray *acls, NSDictionary *result))success
-           failure:(void(^)(ASRemoteIndex *index, NSArray *acls, NSString *errorMessage))failure;
+-(AFHTTPRequestOperation *) addUserKey:(NSArray*)acls
+                          withValidity:(NSUInteger)validity
+                maxQueriesPerIPPerHour:(NSUInteger)maxQueriesPerIPPerHour
+                       maxHitsPerQuery:(NSUInteger)maxHitsPerQuery
+                               success:(void(^)(ASRemoteIndex *index, NSArray *acls, NSDictionary *result))success
+                               failure:(void(^)(ASRemoteIndex *index, NSArray *acls, NSString *errorMessage))failure;
 
 /**
  * Update a user key associated to this index
@@ -332,9 +341,10 @@
  *   - queryParameters: string
  *   - maxQueriesPerIPPerHour: integer
  */
--(void) updateUserKey:(NSString*) key withParams:(NSDictionary*)params
-              success:(void(^)(ASRemoteIndex *index, NSString *key, NSDictionary *params, NSDictionary *result))success
-              failure:(void(^)(ASRemoteIndex *index, NSString *key, NSDictionary *params, NSString *errorMessage))failure;
+-(AFHTTPRequestOperation *) updateUserKey:(NSString*)key
+                               withParams:(NSDictionary*)params
+                                  success:(void(^)(ASRemoteIndex *index, NSString *key, NSDictionary *params, NSDictionary *result))success
+                                  failure:(void(^)(ASRemoteIndex *index, NSString *key, NSDictionary *params, NSString *errorMessage))failure;
 
 /**
  * Update a user key associated to this index
@@ -348,9 +358,10 @@
  *   - settings : allows to get index settings (https only)
  *   - editSettings : allows to change index settings (https only)
  */
--(void) updateUserKey:(NSString*) key withACL:(NSArray*)acls
-              success:(void(^)(ASRemoteIndex *index, NSString *key, NSArray *acls, NSDictionary *result))success
-              failure:(void(^)(ASRemoteIndex *index, NSString *key, NSArray *acls, NSString *errorMessage))failure;
+-(AFHTTPRequestOperation *) updateUserKey:(NSString*)key
+                                  withACL:(NSArray*)acls
+                                  success:(void(^)(ASRemoteIndex *index, NSString *key, NSArray *acls, NSDictionary *result))success
+                                  failure:(void(^)(ASRemoteIndex *index, NSString *key, NSArray *acls, NSString *errorMessage))failure;
 
 /**
  * Update a new user key associated to this index
@@ -367,9 +378,13 @@
  * @param maxQueriesPerIPPerHour Specify the maximum number of API calls allowed from an IP address per hour.  Defaults to 0 (no rate limit).
  * @param maxHitsPerQuery Specify the maximum number of hits this API key can retrieve in one call. Defaults to 0 (unlimited)
  */
--(void) updateUserKey:(NSString*) key withACL:(NSArray*)acls withValidity:(NSUInteger)validity maxQueriesPerIPPerHour:(NSUInteger)maxQueriesPerIPPerHour maxHitsPerQuery:(NSUInteger)maxHitsPerQuery
-              success:(void(^)(ASRemoteIndex *index, NSString *key, NSArray *acls, NSDictionary *result))success
-              failure:(void(^)(ASRemoteIndex *index, NSString *key, NSArray *acls, NSString *errorMessage))failure;
+-(AFHTTPRequestOperation *) updateUserKey:(NSString*)key
+                                  withACL:(NSArray*)acls
+                             withValidity:(NSUInteger)validity
+                   maxQueriesPerIPPerHour:(NSUInteger)maxQueriesPerIPPerHour
+                          maxHitsPerQuery:(NSUInteger)maxHitsPerQuery
+                                  success:(void(^)(ASRemoteIndex *index, NSString *key, NSArray *acls, NSDictionary *result))success
+                                  failure:(void(^)(ASRemoteIndex *index, NSString *key, NSArray *acls, NSString *errorMessage))failure;
 
 /**
  * Browse all index content
@@ -378,9 +393,10 @@
  *             Page is zero-based and defaults to 0. Thus, to retrieve the 10th page you need to set page=9
  * @param hitsPerPage: Pagination parameter used to select the number of hits per page. Defaults to 1000.
  */
--(void) browse:(NSUInteger)page hitsPerPage:(NSUInteger)hitsPerPage
-       success:(void(^)(ASRemoteIndex *index, NSUInteger page, NSUInteger hitsPerPage, NSDictionary *result))success
-       failure:(void(^)(ASRemoteIndex *index, NSUInteger page, NSUInteger hitsPerPage, NSString *errorMessage))failure;
+-(AFHTTPRequestOperation *) browse:(NSUInteger)page
+                       hitsPerPage:(NSUInteger)hitsPerPage
+                           success:(void(^)(ASRemoteIndex *index, NSUInteger page, NSUInteger hitsPerPage, NSDictionary *result))success
+                           failure:(void(^)(ASRemoteIndex *index, NSUInteger page, NSUInteger hitsPerPage, NSString *errorMessage))failure;
 
 /**
  * Browse all index content
@@ -388,9 +404,9 @@
  * @param page Pagination parameter used to select the page to retrieve.
  *             Page is zero-based and defaults to 0. Thus, to retrieve the 10th page you need to set page=9
  */
--(void) browse:(NSUInteger)page
-       success:(void(^)(ASRemoteIndex *index, NSUInteger page, NSDictionary *result))success
-       failure:(void(^)(ASRemoteIndex *index, NSUInteger page, NSString *errorMessage))failure;
+-(AFHTTPRequestOperation *) browse:(NSUInteger)page
+                           success:(void(^)(ASRemoteIndex *index, NSUInteger page, NSDictionary *result))success
+                           failure:(void(^)(ASRemoteIndex *index, NSUInteger page, NSString *errorMessage))failure;
 
 /**
  * Delete all previous search queries

--- a/src/ASRemoteIndex.m
+++ b/src/ASRemoteIndex.m
@@ -42,12 +42,12 @@
     return self;
 }
 
--(void) addObject:(NSDictionary*)object
-          success:(void(^)(ASRemoteIndex *index, NSDictionary *object, NSDictionary *result))success
-          failure:(void(^)(ASRemoteIndex *index, NSDictionary *object, NSString *errorMessage))failure
+-(AFHTTPRequestOperation *) addObject:(NSDictionary*)object
+                              success:(void(^)(ASRemoteIndex *index, NSDictionary *object, NSDictionary *result))success
+                              failure:(void(^)(ASRemoteIndex *index, NSDictionary *object, NSString *errorMessage))failure
 {
     NSString *path = [NSString stringWithFormat:@"/1/indexes/%@", self.urlEncodedIndexName];
-    [self.apiClient performHTTPQuery:path method:@"POST" body:object managers:self.apiClient.writeOperationManagers index:0 timeout:self.apiClient.timeout success:^(id JSON) {
+    return [self.apiClient performHTTPQuery:path method:@"POST" body:object managers:self.apiClient.writeOperationManagers index:0 timeout:self.apiClient.timeout success:^(id JSON) {
         if (success != nil)
             success(self, object, JSON);
     } failure:^(NSString *errorMessage) {
@@ -56,12 +56,13 @@
     }];
 }
 
--(void) addObject:(NSDictionary*)object withObjectID:(NSString*)objectID
-          success:(void(^)(ASRemoteIndex *index, NSDictionary *object, NSString *objectID, NSDictionary *result))success
-          failure:(void(^)(ASRemoteIndex *index, NSDictionary *object, NSString *objectID, NSString *errorMessage))failure
+-(AFHTTPRequestOperation *) addObject:(NSDictionary*)object
+                         withObjectID:(NSString*)objectID
+                              success:(void(^)(ASRemoteIndex *index, NSDictionary *object, NSString *objectID, NSDictionary *result))success
+                              failure:(void(^)(ASRemoteIndex *index, NSDictionary *object, NSString *objectID, NSString *errorMessage))failure
 {
     NSString *path = [NSString stringWithFormat:@"/1/indexes/%@/%@", self.urlEncodedIndexName, [ASAPIClient urlEncode:objectID]];
-    [self.apiClient performHTTPQuery:path method:@"PUT" body:object managers:self.apiClient.writeOperationManagers index:0 timeout:self.apiClient.timeout success:^(id JSON) {
+    return [self.apiClient performHTTPQuery:path method:@"PUT" body:object managers:self.apiClient.writeOperationManagers index:0 timeout:self.apiClient.timeout success:^(id JSON) {
         if (success != nil)
             success(self, object, objectID, JSON);
     } failure:^(NSString *errorMessage) {
@@ -70,18 +71,18 @@
     }];
 }
 
--(void) addObjects:(NSArray*)objects
-           success:(void(^)(ASRemoteIndex *index, NSArray *objects, NSDictionary *result))success
-           failure:(void(^)(ASRemoteIndex *index, NSArray *objects, NSString *errorMessage))failure
+-(AFHTTPRequestOperation *) addObjects:(NSArray*)objects
+                               success:(void(^)(ASRemoteIndex *index, NSArray *objects, NSDictionary *result))success
+                               failure:(void(^)(ASRemoteIndex *index, NSArray *objects, NSString *errorMessage))failure
 {
     NSString *path = [NSString stringWithFormat:@"/1/indexes/%@/batch", self.urlEncodedIndexName];
     NSMutableArray *requests = [[NSMutableArray alloc] initWithCapacity:[objects count]];
     for (NSDictionary *object in objects) {
         [requests addObject:@{@"action": @"addObject",
-                             @"body": object}];
+                              @"body": object}];
     }
     NSDictionary *request = @{@"requests": requests};
-    [self.apiClient performHTTPQuery:path method:@"POST" body:request managers:self.apiClient.writeOperationManagers index:0 timeout:self.apiClient.timeout success:^(id JSON) {
+    return [self.apiClient performHTTPQuery:path method:@"POST" body:request managers:self.apiClient.writeOperationManagers index:0 timeout:self.apiClient.timeout success:^(id JSON) {
         if (success != nil)
             success(self, objects, JSON);
     } failure:^(NSString *errorMessage) {
@@ -90,18 +91,18 @@
     }];
 }
 
--(void) deleteObjects:(NSArray*)objects
-           success:(void(^)(ASRemoteIndex *index, NSArray *objects, NSDictionary *result))success
-           failure:(void(^)(ASRemoteIndex *index, NSArray *objects, NSString *errorMessage))failure
+-(AFHTTPRequestOperation *) deleteObjects:(NSArray*)objects
+                                  success:(void(^)(ASRemoteIndex *index, NSArray *objects, NSDictionary *result))success
+                                  failure:(void(^)(ASRemoteIndex *index, NSArray *objects, NSString *errorMessage))failure
 {
     NSString *path = [NSString stringWithFormat:@"/1/indexes/%@/batch", self.urlEncodedIndexName];
     NSMutableArray *requests = [[NSMutableArray alloc] initWithCapacity:[objects count]];
     for (NSString *object in objects) {
         [requests addObject:@{@"action": @"deleteObject",
-                             @"objectID": object}];
+                              @"objectID": object}];
     }
     NSDictionary *request = @{@"requests": requests};
-    [self.apiClient performHTTPQuery:path method:@"POST" body:request managers:self.apiClient.writeOperationManagers index:0 timeout:self.apiClient.timeout success:^(id JSON) {
+    return [self.apiClient performHTTPQuery:path method:@"POST" body:request managers:self.apiClient.writeOperationManagers index:0 timeout:self.apiClient.timeout success:^(id JSON) {
         if (success != nil)
             success(self, objects, JSON);
     } failure:^(NSString *errorMessage) {
@@ -110,12 +111,12 @@
     }];
 }
 
--(void) getObject:(NSString*)objectID
-          success:(void(^)(ASRemoteIndex *index, NSString *objectID, NSDictionary *result))success
-          failure:(void(^)(ASRemoteIndex *index, NSString *objectID, NSString *errorMessage))failure
+-(AFHTTPRequestOperation *) getObject:(NSString*)objectID
+                              success:(void(^)(ASRemoteIndex *index, NSString *objectID, NSDictionary *result))success
+                              failure:(void(^)(ASRemoteIndex *index, NSString *objectID, NSString *errorMessage))failure
 {
     NSString *path = [NSString stringWithFormat:@"/1/indexes/%@/%@", self.urlEncodedIndexName, [ASAPIClient urlEncode:objectID]];
-    [self.apiClient performHTTPQuery:path method:@"GET" body:nil managers:self.apiClient.searchOperationManagers index:0 timeout:self.apiClient.timeout success:^(id JSON) {
+    return [self.apiClient performHTTPQuery:path method:@"GET" body:nil managers:self.apiClient.searchOperationManagers index:0 timeout:self.apiClient.timeout success:^(id JSON) {
         if (success != nil)
             success(self, objectID, JSON);
     } failure:^(NSString *errorMessage) {
@@ -124,9 +125,10 @@
     }];
 }
 
--(void) getObject:(NSString*)objectID attributesToRetrieve:(NSArray*)attributes
-          success:(void(^)(ASRemoteIndex *index, NSString *objectID, NSArray *attributesToRetrieve, NSDictionary *result))success
-          failure:(void(^)(ASRemoteIndex *index, NSString *objectID, NSArray *attributesToRetrieve, NSString *errorMessage))failure
+-(AFHTTPRequestOperation *) getObject:(NSString*)objectID
+                 attributesToRetrieve:(NSArray*)attributes
+                              success:(void(^)(ASRemoteIndex *index, NSString *objectID, NSArray *attributesToRetrieve, NSDictionary *result))success
+                              failure:(void(^)(ASRemoteIndex *index, NSString *objectID, NSArray *attributesToRetrieve, NSString *errorMessage))failure
 {
     NSMutableString *path = [NSMutableString stringWithFormat:@"/1/indexes/%@/%@?attributes=", self.urlEncodedIndexName, [ASAPIClient urlEncode:objectID]];
     BOOL firstEntry = YES;
@@ -136,7 +138,7 @@
         [path appendString:[ASAPIClient urlEncode:attribute]];
         firstEntry = NO;
     }
-    [self.apiClient performHTTPQuery:path method:@"GET" body:nil managers:self.apiClient.searchOperationManagers index:0 timeout:self.apiClient.timeout success:^(id JSON) {
+    return [self.apiClient performHTTPQuery:path method:@"GET" body:nil managers:self.apiClient.searchOperationManagers index:0 timeout:self.apiClient.timeout success:^(id JSON) {
         if (success != nil)
             success(self, objectID, attributes, JSON);
     } failure:^(NSString *errorMessage) {
@@ -145,9 +147,9 @@
     }];
 }
 
--(void) getObjects:(NSArray*)objectIDs
-          success:(void(^)(ASRemoteIndex *index, NSArray *objectIDs, NSDictionary *result))success
-          failure:(void(^)(ASRemoteIndex *index, NSArray *objectIDs, NSString *errorMessage))failure
+-(AFHTTPRequestOperation *) getObjects:(NSArray*)objectIDs
+                               success:(void(^)(ASRemoteIndex *index, NSArray *objectIDs, NSDictionary *result))success
+                               failure:(void(^)(ASRemoteIndex *index, NSArray *objectIDs, NSString *errorMessage))failure
 {
     NSString *path = [NSString stringWithFormat:@"/1/indexes/*/objects"];
     
@@ -155,9 +157,9 @@
     for (NSString *id in objectIDs) {
         [requests addObject:@{@"indexName": self.indexName, @"objectID": id}];
     }
-
     
-    [self.apiClient performHTTPQuery:path method:@"POST" body:@{@"requests": requests} managers:self.apiClient.searchOperationManagers index:0 timeout:self.apiClient.timeout success:^(id JSON) {
+    
+    return [self.apiClient performHTTPQuery:path method:@"POST" body:@{@"requests": requests} managers:self.apiClient.searchOperationManagers index:0 timeout:self.apiClient.timeout success:^(id JSON) {
         if (success != nil)
             success(self, objectIDs, JSON);
     } failure:^(NSString *errorMessage) {
@@ -166,12 +168,13 @@
     }];
 }
 
--(void) partialUpdateObject:(NSDictionary*)partialObject objectID:(NSString*)objectID
-                    success:(void(^)(ASRemoteIndex *index, NSDictionary *partialObject, NSString *objectID, NSDictionary *result))success
-                    failure:(void(^)(ASRemoteIndex *index, NSDictionary *partialObject, NSString *objectID, NSString *errorMessage))failure
+-(AFHTTPRequestOperation *) partialUpdateObject:(NSDictionary*)partialObject
+                                       objectID:(NSString*)objectID
+                                        success:(void(^)(ASRemoteIndex *index, NSDictionary *partialObject, NSString *objectID, NSDictionary *result))success
+                                        failure:(void(^)(ASRemoteIndex *index, NSDictionary *partialObject, NSString *objectID, NSString *errorMessage))failure
 {
     NSString *path = [NSString stringWithFormat:@"/1/indexes/%@/%@/partial", self.urlEncodedIndexName, [ASAPIClient urlEncode:objectID]];
-    [self.apiClient performHTTPQuery:path method:@"POST" body:partialObject managers:self.apiClient.writeOperationManagers index:0 timeout:self.apiClient.timeout success:^(id JSON) {
+    return [self.apiClient performHTTPQuery:path method:@"POST" body:partialObject managers:self.apiClient.writeOperationManagers index:0 timeout:self.apiClient.timeout success:^(id JSON) {
         if (success != nil)
             success(self, partialObject, objectID, JSON);
     } failure:^(NSString *errorMessage) {
@@ -180,19 +183,19 @@
     }];
 }
 
--(void) partialUpdateObjects:(NSArray*)objects
-            success:(void(^)(ASRemoteIndex *index, NSArray *objects, NSDictionary *result))success
-            failure:(void(^)(ASRemoteIndex *index, NSArray *objects, NSString *errorMessage))failure
+-(AFHTTPRequestOperation *) partialUpdateObjects:(NSArray*)objects
+                                         success:(void(^)(ASRemoteIndex *index, NSArray *objects, NSDictionary *result))success
+                                         failure:(void(^)(ASRemoteIndex *index, NSArray *objects, NSString *errorMessage))failure
 {
     NSString *path = [NSString stringWithFormat:@"/1/indexes/%@/batch", self.urlEncodedIndexName];
     NSMutableArray *requests = [[NSMutableArray alloc] initWithCapacity:[objects count]];
     for (NSDictionary *object in objects) {
         [requests addObject:@{@"action": @"partialUpdateObject",
-                             @"objectID": [object valueForKey:@"objectID"],
-                             @"body": object}];
+                              @"objectID": [object valueForKey:@"objectID"],
+                              @"body": object}];
     }
     NSDictionary *request = @{@"requests": requests};
-    [self.apiClient performHTTPQuery:path method:@"POST" body:request managers:self.apiClient.writeOperationManagers index:0 timeout:self.apiClient.timeout success:^(id JSON) {
+    return [self.apiClient performHTTPQuery:path method:@"POST" body:request managers:self.apiClient.writeOperationManagers index:0 timeout:self.apiClient.timeout success:^(id JSON) {
         if (success != nil)
             success(self, objects, JSON);
     } failure:^(NSString *errorMessage) {
@@ -201,12 +204,13 @@
     }];
 }
 
--(void) saveObject:(NSDictionary*)object objectID:(NSString*)objectID
-           success:(void(^)(ASRemoteIndex *index, NSDictionary *object, NSString *objectID, NSDictionary *result))success
-           failure:(void(^)(ASRemoteIndex *index, NSDictionary *object, NSString *objectID, NSString *errorMessage))failure
+-(AFHTTPRequestOperation *) saveObject:(NSDictionary*)object
+                              objectID:(NSString*)objectID
+                               success:(void(^)(ASRemoteIndex *index, NSDictionary *object, NSString *objectID, NSDictionary *result))success
+                               failure:(void(^)(ASRemoteIndex *index, NSDictionary *object, NSString *objectID, NSString *errorMessage))failure
 {
     NSString *path = [NSString stringWithFormat:@"/1/indexes/%@/%@", self.urlEncodedIndexName, [ASAPIClient urlEncode:objectID]];
-    [self.apiClient performHTTPQuery:path method:@"PUT" body:object managers:self.apiClient.writeOperationManagers index:0 timeout:self.apiClient.timeout success:^(id JSON) {
+    return [self.apiClient performHTTPQuery:path method:@"PUT" body:object managers:self.apiClient.writeOperationManagers index:0 timeout:self.apiClient.timeout success:^(id JSON) {
         if (success != nil)
             success(self, object, objectID, JSON);
     } failure:^(NSString *errorMessage) {
@@ -215,9 +219,9 @@
     }];
 }
 
--(void) saveObjects:(NSArray*)objects
-            success:(void(^)(ASRemoteIndex *index, NSArray *objects, NSDictionary *result))success
-            failure:(void(^)(ASRemoteIndex *index, NSArray *objects, NSString *errorMessage))failure
+-(AFHTTPRequestOperation *) saveObjects:(NSArray*)objects
+                                success:(void(^)(ASRemoteIndex *index, NSArray *objects, NSDictionary *result))success
+                                failure:(void(^)(ASRemoteIndex *index, NSArray *objects, NSString *errorMessage))failure
 {
     NSString *path = [NSString stringWithFormat:@"/1/indexes/%@/batch", self.urlEncodedIndexName];
     NSMutableArray *requests = [[NSMutableArray alloc] initWithCapacity:[objects count]];
@@ -227,7 +231,7 @@
                               @"body": object}];
     }
     NSDictionary *request = @{@"requests": requests};
-    [self.apiClient performHTTPQuery:path method:@"POST" body:request managers:self.apiClient.writeOperationManagers index:0 timeout:self.apiClient.timeout success:^(id JSON) {
+    return [self.apiClient performHTTPQuery:path method:@"POST" body:request managers:self.apiClient.writeOperationManagers index:0 timeout:self.apiClient.timeout success:^(id JSON) {
         if (success != nil)
             success(self, objects, JSON);
     } failure:^(NSString *errorMessage) {
@@ -236,17 +240,14 @@
     }];
 }
 
--(void) deleteObject:(NSString*)objectID
-             success:(void(^)(ASRemoteIndex *index, NSString *objectID, NSDictionary *result))success
-             failure:(void(^)(ASRemoteIndex *index, NSString *objectID, NSString *errorMessage))failure
+-(AFHTTPRequestOperation *) deleteObject:(NSString*)objectID
+                                 success:(void(^)(ASRemoteIndex *index, NSString *objectID, NSDictionary *result))success
+                                 failure:(void(^)(ASRemoteIndex *index, NSString *objectID, NSString *errorMessage))failure
 {
-    if (objectID == nil || [objectID length] == 0) {
-        failure(self, objectID, @"empty objectID is not allowed");
-        return;
-    }
+    NSAssert(objectID == nil || [objectID length] == 0, @"empty objectID is not allowed");
     
     NSString *path = [NSString stringWithFormat:@"/1/indexes/%@/%@", self.urlEncodedIndexName, [ASAPIClient urlEncode:objectID]];
-    [self.apiClient performHTTPQuery:path method:@"DELETE" body:nil managers:self.apiClient.writeOperationManagers index:0 timeout:self.apiClient.timeout success:^(id JSON) {
+    return [self.apiClient performHTTPQuery:path method:@"DELETE" body:nil managers:self.apiClient.writeOperationManagers index:0 timeout:self.apiClient.timeout success:^(id JSON) {
         if (success != nil)
             success(self, objectID, JSON);
     } failure:^(NSString *errorMessage) {
@@ -255,14 +256,14 @@
     }];
 }
 
--(void) search:(ASQuery*)query
-       success:(void(^)(ASRemoteIndex *index, ASQuery *query, NSDictionary *result))success
-       failure:(void(^)(ASRemoteIndex *index, ASQuery *query, NSString *errorMessage))failure
+-(AFHTTPRequestOperation *) search:(ASQuery*)query
+                           success:(void(^)(ASRemoteIndex *index, ASQuery *query, NSDictionary *result))success
+                           failure:(void(^)(ASRemoteIndex *index, ASQuery *query, NSString *errorMessage))failure
 {
     NSString *queryParams = [query buildURL];
     NSString *path = [NSString stringWithFormat:@"/1/indexes/%@/query", self.urlEncodedIndexName];
     NSMutableDictionary *dict = [NSMutableDictionary dictionaryWithObject:queryParams forKey:@"params"];
-    [self.apiClient performHTTPQuery:path method:@"POST" body:dict managers:self.apiClient.searchOperationManagers index:0 timeout:self.apiClient.searchTimeout success:^(id JSON) {
+    return [self.apiClient performHTTPQuery:path method:@"POST" body:dict managers:self.apiClient.searchOperationManagers index:0 timeout:self.apiClient.searchTimeout success:^(id JSON) {
         if (success != nil)
             success(self, query, JSON);
     } failure:^(NSString *errorMessage) {
@@ -277,12 +278,12 @@
     [self.apiClient cancelQueries:@"POST" path:path];
 }
 
--(void) waitTask:(NSString*)taskID
-success:(void(^)(ASRemoteIndex *index, NSString *taskID, NSDictionary *result))success
-failure:(void(^)(ASRemoteIndex *index, NSString *taskID, NSString *errorMessage))failure
+-(AFHTTPRequestOperation *) waitTask:(NSString*)taskID
+                             success:(void(^)(ASRemoteIndex *index, NSString *taskID, NSDictionary *result))success
+                             failure:(void(^)(ASRemoteIndex *index, NSString *taskID, NSString *errorMessage))failure
 {
     NSString *path = [NSString stringWithFormat:@"/1/indexes/%@/task/%@", self.urlEncodedIndexName, taskID];
-    [self.apiClient performHTTPQuery:path method:@"GET" body:nil managers:self.apiClient.searchOperationManagers index:0 timeout:self.apiClient.timeout success:^(id JSON) {
+    return [self.apiClient performHTTPQuery:path method:@"GET" body:nil managers:self.apiClient.searchOperationManagers index:0 timeout:self.apiClient.timeout success:^(id JSON) {
         NSString *status = [JSON valueForKey:@"status"];
         if ([status compare:@"published"] == NSOrderedSame) {
             if (success != nil)
@@ -297,11 +298,11 @@ failure:(void(^)(ASRemoteIndex *index, NSString *taskID, NSString *errorMessage)
     }];
 }
 
--(void) getSettings:(void(^)(ASRemoteIndex *index, NSDictionary *result))success
-            failure:(void(^)(ASRemoteIndex *index, NSString *errorMessage))failure
+-(AFHTTPRequestOperation *) getSettings:(void(^)(ASRemoteIndex *index, NSDictionary *result))success
+                                failure:(void(^)(ASRemoteIndex *index, NSString *errorMessage))failure
 {
     NSString *path = [NSString stringWithFormat:@"/1/indexes/%@/settings", self.urlEncodedIndexName];
-    [self.apiClient performHTTPQuery:path method:@"GET" body:nil managers:self.apiClient.searchOperationManagers index:0 timeout:self.apiClient.timeout success:^(id JSON) {
+    return [self.apiClient performHTTPQuery:path method:@"GET" body:nil managers:self.apiClient.searchOperationManagers index:0 timeout:self.apiClient.timeout success:^(id JSON) {
         if (success != nil)
             success(self, JSON);
     } failure:^(NSString *errorMessage) {
@@ -310,12 +311,12 @@ failure:(void(^)(ASRemoteIndex *index, NSString *taskID, NSString *errorMessage)
     }];
 }
 
--(void) setSettings:(NSDictionary*)settings
-            success:(void(^)(ASRemoteIndex *index, NSDictionary *settings, NSDictionary *result))success
-            failure:(void(^)(ASRemoteIndex *index, NSDictionary *settings, NSString *errorMessage))failure
+-(AFHTTPRequestOperation *) setSettings:(NSDictionary*)settings
+                                success:(void(^)(ASRemoteIndex *index, NSDictionary *settings, NSDictionary *result))success
+                                failure:(void(^)(ASRemoteIndex *index, NSDictionary *settings, NSString *errorMessage))failure
 {
     NSString *path = [NSString stringWithFormat:@"/1/indexes/%@/settings", self.urlEncodedIndexName];
-    [self.apiClient performHTTPQuery:path method:@"PUT" body:settings managers:self.apiClient.writeOperationManagers index:0 timeout:self.apiClient.timeout success:^(id JSON) {
+    return [self.apiClient performHTTPQuery:path method:@"PUT" body:settings managers:self.apiClient.writeOperationManagers index:0 timeout:self.apiClient.timeout success:^(id JSON) {
         if (success != nil)
             success(self, settings, JSON);
     } failure:^(NSString *errorMessage) {
@@ -324,12 +325,12 @@ failure:(void(^)(ASRemoteIndex *index, NSString *taskID, NSString *errorMessage)
     }];
 }
 
--(void) clearIndex:(void(^)(ASRemoteIndex *index, NSDictionary *result))success
-            failure:(void(^)(ASRemoteIndex *index, NSString *errorMessage))failure
+-(AFHTTPRequestOperation *) clearIndex:(void(^)(ASRemoteIndex *index, NSDictionary *result))success
+                               failure:(void(^)(ASRemoteIndex *index, NSString *errorMessage))failure
 {
     NSDictionary *obj = [[NSDictionary alloc] init];
     NSString *path = [NSString stringWithFormat:@"/1/indexes/%@/clear", self.urlEncodedIndexName];
-    [self.apiClient performHTTPQuery:path method:@"POST" body:obj managers:self.apiClient.writeOperationManagers index:0 timeout:self.apiClient.timeout success:^(id JSON) {
+    return [self.apiClient performHTTPQuery:path method:@"POST" body:obj managers:self.apiClient.writeOperationManagers index:0 timeout:self.apiClient.timeout success:^(id JSON) {
         if (success != nil)
             success(self, JSON);
     } failure:^(NSString *errorMessage) {
@@ -338,22 +339,23 @@ failure:(void(^)(ASRemoteIndex *index, NSString *taskID, NSString *errorMessage)
     }];
 }
 
--(void) listUserKeys:(void(^)(ASRemoteIndex *index, NSDictionary* result))success
-             failure:(void(^)(ASRemoteIndex *index, NSString *errorMessage))failure
+-(AFHTTPRequestOperation *) listUserKeys:(void(^)(ASRemoteIndex *index, NSDictionary* result))success
+                                 failure:(void(^)(ASRemoteIndex *index, NSString *errorMessage))failure
 {
     NSString *path = [NSString stringWithFormat:@"/1/indexes/%@/keys", self.urlEncodedIndexName];
-    [self.apiClient performHTTPQuery:path method:@"GET" body:nil managers:self.apiClient.searchOperationManagers index:0 timeout:self.apiClient.timeout success:^(id JSON) {
+    return [self.apiClient performHTTPQuery:path method:@"GET" body:nil managers:self.apiClient.searchOperationManagers index:0 timeout:self.apiClient.timeout success:^(id JSON) {
         success(self, JSON);
     } failure:^(NSString *errorMessage) {
         failure(self, errorMessage);
     }];
 }
 
--(void) getUserKeyACL:(NSString*)key success:(void(^)(ASRemoteIndex *index, NSString *key, NSDictionary *result))success
-              failure:(void(^)(ASRemoteIndex *index, NSString *key, NSString *errorMessage))failure
+-(AFHTTPRequestOperation *) getUserKeyACL:(NSString*)key
+                                  success:(void(^)(ASRemoteIndex *index, NSString *key, NSDictionary *result))success
+                                  failure:(void(^)(ASRemoteIndex *index, NSString *key, NSString *errorMessage))failure
 {
     NSString *path = [NSString stringWithFormat:@"/1/indexes/%@/keys/%@", self.urlEncodedIndexName, key];
-    [self.apiClient performHTTPQuery:path method:@"GET" body:nil managers:self.apiClient.searchOperationManagers index:0 timeout:self.apiClient.timeout success:^(id JSON) {
+    return [self.apiClient performHTTPQuery:path method:@"GET" body:nil managers:self.apiClient.searchOperationManagers index:0 timeout:self.apiClient.timeout success:^(id JSON) {
         if (success != nil)
             success(self, key, JSON);
     } failure:^(NSString *errorMessage) {
@@ -362,12 +364,13 @@ failure:(void(^)(ASRemoteIndex *index, NSString *taskID, NSString *errorMessage)
     }];
 }
 
--(void) browse:(NSUInteger)page hitsPerPage:(NSUInteger)hitsPerPage
-       success:(void(^)(ASRemoteIndex *index, NSUInteger page, NSUInteger hitsPerPage, NSDictionary *result))success
-       failure:(void(^)(ASRemoteIndex *index, NSUInteger page, NSUInteger hitsPerPage, NSString *errorMessage))failure
+-(AFHTTPRequestOperation *) browse:(NSUInteger)page
+                       hitsPerPage:(NSUInteger)hitsPerPage
+                           success:(void(^)(ASRemoteIndex *index, NSUInteger page, NSUInteger hitsPerPage, NSDictionary *result))success
+                           failure:(void(^)(ASRemoteIndex *index, NSUInteger page, NSUInteger hitsPerPage, NSString *errorMessage))failure
 {
     NSString *path = [NSString stringWithFormat:@"/1/indexes/%@/browse?page=%lu&hitsPerPage=%lu", self.urlEncodedIndexName, (unsigned long)page, (unsigned long)hitsPerPage];
-    [self.apiClient performHTTPQuery:path method:@"GET" body:nil managers:self.apiClient.searchOperationManagers index:0 timeout:self.apiClient.timeout success:^(id JSON) {
+    return [self.apiClient performHTTPQuery:path method:@"GET" body:nil managers:self.apiClient.searchOperationManagers index:0 timeout:self.apiClient.timeout success:^(id JSON) {
         if (success != nil)
             success(self, page, hitsPerPage, JSON);
     } failure:^(NSString *errorMessage) {
@@ -376,12 +379,12 @@ failure:(void(^)(ASRemoteIndex *index, NSString *taskID, NSString *errorMessage)
     }];
 }
 
--(void) browse:(NSUInteger)page
-       success:(void(^)(ASRemoteIndex *index, NSUInteger page, NSDictionary *result))success
-       failure:(void(^)(ASRemoteIndex *index, NSUInteger page, NSString *errorMessage))failure
+-(AFHTTPRequestOperation *) browse:(NSUInteger)page
+                           success:(void(^)(ASRemoteIndex *index, NSUInteger page, NSDictionary *result))success
+                           failure:(void(^)(ASRemoteIndex *index, NSUInteger page, NSString *errorMessage))failure
 {
     NSString *path = [NSString stringWithFormat:@"/1/indexes/%@/browse?page=%lu", self.urlEncodedIndexName, (unsigned long)page];
-    [self.apiClient performHTTPQuery:path method:@"GET" body:nil managers:self.apiClient.searchOperationManagers index:0 timeout:self.apiClient.timeout success:^(id JSON) {
+    return [self.apiClient performHTTPQuery:path method:@"GET" body:nil managers:self.apiClient.searchOperationManagers index:0 timeout:self.apiClient.timeout success:^(id JSON) {
         if (success != nil)
             success(self, page, JSON);
     } failure:^(NSString *errorMessage) {
@@ -391,11 +394,12 @@ failure:(void(^)(ASRemoteIndex *index, NSString *taskID, NSString *errorMessage)
 }
 
 
--(void) deleteUserKey:(NSString*)key success:(void(^)(ASRemoteIndex *index, NSString *key, NSDictionary *result))success
-              failure:(void(^)(ASRemoteIndex *index, NSString *key, NSString *errorMessage))failure
+-(AFHTTPRequestOperation *) deleteUserKey:(NSString*)key
+                                  success:(void(^)(ASRemoteIndex *index, NSString *key, NSDictionary *result))success
+                                  failure:(void(^)(ASRemoteIndex *index, NSString *key, NSString *errorMessage))failure
 {
     NSString *path = [NSString stringWithFormat:@"/1/indexes/%@/keys/%@", self.urlEncodedIndexName, key];
-    [self.apiClient performHTTPQuery:path method:@"DELETE" body:nil managers:self.apiClient.writeOperationManagers index:0 timeout:self.apiClient.timeout success:^(id JSON) {
+    return [self.apiClient performHTTPQuery:path method:@"DELETE" body:nil managers:self.apiClient.writeOperationManagers index:0 timeout:self.apiClient.timeout success:^(id JSON) {
         if (success != nil)
             success(self, key, JSON);
     } failure:^(NSString *errorMessage) {
@@ -404,12 +408,12 @@ failure:(void(^)(ASRemoteIndex *index, NSString *taskID, NSString *errorMessage)
     }];
 }
 
--(void) addUserKey:(NSArray*)acls
-           success:(void(^)(ASRemoteIndex *index, NSArray *acls, NSDictionary *result))success
-           failure:(void(^)(ASRemoteIndex *index, NSArray *acls, NSString *errorMessage))failure
+-(AFHTTPRequestOperation *) addUserKey:(NSArray*)acls
+                               success:(void(^)(ASRemoteIndex *index, NSArray *acls, NSDictionary *result))success
+                               failure:(void(^)(ASRemoteIndex *index, NSArray *acls, NSString *errorMessage))failure
 {
     NSDictionary *params = [NSMutableDictionary dictionaryWithObject:acls forKey:@"acl"];
-    [self addUserKey:acls withParams:params success:^(ASRemoteIndex *index, NSArray* acls, NSDictionary *params, NSDictionary *result) {
+    return [self addUserKey:acls withParams:params success:^(ASRemoteIndex *index, NSArray* acls, NSDictionary *params, NSDictionary *result) {
         if (success != nil)
             success(index, acls, result);
     } failure:^(ASRemoteIndex *index, NSArray* acls, NSDictionary *params, NSString *errorMessage) {
@@ -418,13 +422,14 @@ failure:(void(^)(ASRemoteIndex *index, NSString *taskID, NSString *errorMessage)
     }];
 }
 
--(void) addUserKey:(NSArray*)acls withParams:(NSDictionary*)params
-           success:(void(^)(ASRemoteIndex *index, NSArray* acls, NSDictionary *params, NSDictionary *result))success
-           failure:(void(^)(ASRemoteIndex *index, NSArray* acls, NSDictionary *params, NSString *errorMessage))failure
+-(AFHTTPRequestOperation *) addUserKey:(NSArray*)acls
+                            withParams:(NSDictionary*)params
+                               success:(void(^)(ASRemoteIndex *index, NSArray* acls, NSDictionary *params, NSDictionary *result))success
+                               failure:(void(^)(ASRemoteIndex *index, NSArray* acls, NSDictionary *params, NSString *errorMessage))failure
 {
     [params setValue:acls forKey:@"acl"];
     NSString *path = [NSString stringWithFormat:@"/1/indexes/%@/keys", self.urlEncodedIndexName];
-    [self.apiClient performHTTPQuery:path method:@"POST" body:params managers:self.apiClient.writeOperationManagers index:0 timeout:self.apiClient.timeout success:^(id JSON) {
+    return [self.apiClient performHTTPQuery:path method:@"POST" body:params managers:self.apiClient.writeOperationManagers index:0 timeout:self.apiClient.timeout success:^(id JSON) {
         if (success != nil)
             success(self, acls, params, JSON);
     } failure:^(NSString *errorMessage) {
@@ -433,16 +438,19 @@ failure:(void(^)(ASRemoteIndex *index, NSString *taskID, NSString *errorMessage)
     }];
 }
 
--(void) addUserKey:(NSArray*)acls withValidity:(NSUInteger)validity maxQueriesPerIPPerHour:(NSUInteger)maxQueriesPerIPPerHour maxHitsPerQuery:(NSUInteger)maxHitsPerQuery
-           success:(void(^)(ASRemoteIndex *index, NSArray *acls, NSDictionary *result))success
-           failure:(void(^)(ASRemoteIndex *index, NSArray *acls, NSString *errorMessage))failure;
+-(AFHTTPRequestOperation *) addUserKey:(NSArray*)acls
+                          withValidity:(NSUInteger)validity
+                maxQueriesPerIPPerHour:(NSUInteger)maxQueriesPerIPPerHour
+                       maxHitsPerQuery:(NSUInteger)maxHitsPerQuery
+                               success:(void(^)(ASRemoteIndex *index, NSArray *acls, NSDictionary *result))success
+                               failure:(void(^)(ASRemoteIndex *index, NSArray *acls, NSString *errorMessage))failure;
 {
-    NSMutableDictionary *dict = [NSMutableDictionary dictionaryWithObjectsAndKeys:acls, @"acl", 
-                                @(validity), @"validity", 
-                                @(maxQueriesPerIPPerHour), @"maxQueriesPerIPPerHour", 
-                                @(maxHitsPerQuery), @"maxHitsPerQuery", 
-                                nil];
-    [self addUserKey:acls withParams:dict success:^(ASRemoteIndex *index, NSArray* acls, NSDictionary *params, NSDictionary *result) {
+    NSMutableDictionary *dict = [NSMutableDictionary dictionaryWithObjectsAndKeys:acls, @"acl",
+                                 @(validity), @"validity",
+                                 @(maxQueriesPerIPPerHour), @"maxQueriesPerIPPerHour",
+                                 @(maxHitsPerQuery), @"maxHitsPerQuery",
+                                 nil];
+    return [self addUserKey:acls withParams:dict success:^(ASRemoteIndex *index, NSArray* acls, NSDictionary *params, NSDictionary *result) {
         if (success != nil)
             success(index, acls, result);
     } failure:^(ASRemoteIndex *index, NSArray* acls, NSDictionary *params, NSString *errorMessage) {
@@ -451,11 +459,13 @@ failure:(void(^)(ASRemoteIndex *index, NSString *taskID, NSString *errorMessage)
     }];
 }
 
--(void) updateUserKey:(NSString*) key withParams:(NSDictionary*)params success:(void(^)(ASRemoteIndex *index, NSString *key, NSDictionary *params, NSDictionary *result))success
-              failure:(void(^)(ASRemoteIndex *index, NSString *key, NSDictionary *params, NSString *errorMessage))failure
+-(AFHTTPRequestOperation *) updateUserKey:(NSString*)key
+                               withParams:(NSDictionary*)params
+                                  success:(void(^)(ASRemoteIndex *index, NSString *key, NSDictionary *params, NSDictionary *result))success
+                                  failure:(void(^)(ASRemoteIndex *index, NSString *key, NSDictionary *params, NSString *errorMessage))failure
 {
     NSString *path = [NSString stringWithFormat:@"/1/indexes/%@/keys/%@", self.urlEncodedIndexName, key];
-    [self.apiClient performHTTPQuery:path method:@"PUT" body:params managers:self.apiClient.writeOperationManagers index:0 timeout:self.apiClient.timeout success:^(id JSON) {
+    return [self.apiClient performHTTPQuery:path method:@"PUT" body:params managers:self.apiClient.writeOperationManagers index:0 timeout:self.apiClient.timeout success:^(id JSON) {
         if (success != nil)
             success(self, key, params, JSON);
     } failure:^(NSString *errorMessage) {
@@ -464,11 +474,13 @@ failure:(void(^)(ASRemoteIndex *index, NSString *taskID, NSString *errorMessage)
     }];
 }
 
--(void) updateUserKey:(NSString*) key withACL:(NSArray*)acls success:(void(^)(ASRemoteIndex *index, NSString *key, NSArray *acls, NSDictionary *result))success
-           failure:(void(^)(ASRemoteIndex *index, NSString *key, NSArray *acls, NSString *errorMessage))failure
+-(AFHTTPRequestOperation *) updateUserKey:(NSString*)key
+                                  withACL:(NSArray*)acls
+                                  success:(void(^)(ASRemoteIndex *index, NSString *key, NSArray *acls, NSDictionary *result))success
+                                  failure:(void(^)(ASRemoteIndex *index, NSString *key, NSArray *acls, NSString *errorMessage))failure
 {
     NSMutableDictionary *dict = [NSMutableDictionary dictionaryWithObject:acls forKey:@"acl"];
-    [self updateUserKey:key withParams:dict success:^(ASRemoteIndex *index, NSString *key, NSDictionary *params, NSDictionary *result) {
+    return [self updateUserKey:key withParams:dict success:^(ASRemoteIndex *index, NSString *key, NSDictionary *params, NSDictionary *result) {
         if (success != nil)
             success(index, key, acls, result);
     } failure:^(ASRemoteIndex *index, NSString *key, NSDictionary *params, NSString *errorMessage) {
@@ -477,16 +489,20 @@ failure:(void(^)(ASRemoteIndex *index, NSString *taskID, NSString *errorMessage)
     }];
 }
 
--(void) updateUserKey:(NSString*) key withACL:(NSArray*)acls withValidity:(NSUInteger)validity maxQueriesPerIPPerHour:(NSUInteger)maxQueriesPerIPPerHour maxHitsPerQuery:(NSUInteger)maxHitsPerQuery
-           success:(void(^)(ASRemoteIndex *index, NSString *key, NSArray *acls, NSDictionary *result))success
-           failure:(void(^)(ASRemoteIndex *index, NSString *key, NSArray *acls, NSString *errorMessage))failure;
+-(AFHTTPRequestOperation *) updateUserKey:(NSString*)key
+                                  withACL:(NSArray*)acls
+                             withValidity:(NSUInteger)validity
+                   maxQueriesPerIPPerHour:(NSUInteger)maxQueriesPerIPPerHour
+                          maxHitsPerQuery:(NSUInteger)maxHitsPerQuery
+                                  success:(void(^)(ASRemoteIndex *index, NSString *key, NSArray *acls, NSDictionary *result))success
+                                  failure:(void(^)(ASRemoteIndex *index, NSString *key, NSArray *acls, NSString *errorMessage))failure;
 {
     NSMutableDictionary *dict = [NSMutableDictionary dictionaryWithObjectsAndKeys:acls, @"acl",
                                  @(validity), @"validity",
                                  @(maxQueriesPerIPPerHour), @"maxQueriesPerIPPerHour",
                                  @(maxHitsPerQuery), @"maxHitsPerQuery",
                                  nil];
-    [self updateUserKey:key withParams:dict success:^(ASRemoteIndex *index, NSString *key, NSDictionary *params, NSDictionary *result) {
+    return [self updateUserKey:key withParams:dict success:^(ASRemoteIndex *index, NSString *key, NSDictionary *params, NSDictionary *result) {
         if (success != nil)
             success(index, key, acls, result);
     } failure:^(ASRemoteIndex *index, NSString *key, NSDictionary *params, NSString *errorMessage) {

--- a/src/ASRemoteIndex.m
+++ b/src/ASRemoteIndex.m
@@ -285,7 +285,7 @@
     return [self waitTask:taskID withTimeToSleep:0.1f success:success failure:failure];
 }
 
--(AFHTTPRequestOperation *) waitTask:(NSString*)taskID withTimeToSleep:(float)timeToSleep
+-(AFHTTPRequestOperation *) waitTask:(NSString*)taskID withTimeToSleep:(NSTimeInterval)timeToSleep
                              success:(void(^)(ASRemoteIndex *index, NSString *taskID, NSDictionary *result))success
                              failure:(void(^)(ASRemoteIndex *index, NSString *taskID, NSString *errorMessage))failure
 {


### PR DESCRIPTION
Changed every method with success and failure parameteres to return AFHTTPRequestOperation.
This is needed if developer is willing to control operations by himself. For example if we need to load data with an infinite scrolling and want to cancel and start operations at some point but have them ready before they are started.

Added `@property (assign, nonatomic) BOOL startOperationsManually`(by default NO) in ASAPIClient to avoid adding operation to operation queue(which means it won't start automatically) in 
````
-(AFHTTPRequestOperation *) performHTTPQuery: (NSString*)path method:(NSString*)method body:(NSDictionary*)body managers:(NSArray*)managers index:(NSUInteger)index timeout:(NSTimeInterval)timeout success:(void(^)(id JSON))success failure:(void(^)(NSString *errorMessage))failure;
```
method so operation could be started manually from outside.

Replaced some code in 
```
-(AFHTTPRequestOperation *) deleteObject:(NSString*)objectID success:(void(^)(ASRemoteIndex *index, NSString *objectID, NSDictionary *result))success failure:(void(^)(ASRemoteIndex *index, NSString *objectID, NSString *errorMessage))failure;
```
method with `NSAssert(objectID == nil || [objectID length] == 0, @"empty objectID is not allowed");` as it seems more of an error to be shown for developer(so he can avoid making this error occur) and not the one to fail at runtime.

Replaced float with NSTimeInterval in method as it should receive NSTimeInterval which is double, not float
```
-(AFHTTPRequestOperation *) waitTask:(NSString*)taskID withTimeToSleep:(NSTimeInterval)timeToSleep success:(void(^)(ASRemoteIndex *index, NSString *taskID, NSDictionary *result))success failure:(void(^)(ASRemoteIndex *index, NSString *taskID, NSString *errorMessage))failure;
```