### PR TITLE
Cache for search query

### DIFF
--- a/AlgoliaSearch-Client.podspec
+++ b/AlgoliaSearch-Client.podspec
@@ -13,8 +13,8 @@ Pod::Spec.new do |s|
   s.osx.deployment_target = '10.8'
   s.osx.frameworks = 'CoreServices', 'SystemConfiguration', 'Security'
 
-  s.source_files = 'src'
-  s.requires_arc = true
+  s.source_files = 'src/*.{h,m}'
+  s.private_header_files = 'src/ASExpiringCache*.h'
 
   s.dependency 'AFNetworking', '~> 2.2'
 end

--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,10 @@ CHANGELOG
 
 2015-07-XX X.X.X
   * New browseFromCursor method
+  * Add search cache (disabled by default)
+
+2015-07-01 3.5.1
+  * Fix grouping
 
 2015-07-01 3.5.0
   * ASQuery implements protocol NSCopying

--- a/algoliasearch-client-objc.xcodeproj/project.pbxproj
+++ b/algoliasearch-client-objc.xcodeproj/project.pbxproj
@@ -22,6 +22,8 @@
 		591C936818E267B5001F1A0F /* ASRemoteIndex.m in Sources */ = {isa = PBXBuildFile; fileRef = 591C936418E267B5001F1A0F /* ASRemoteIndex.m */; };
 		592EEA9118E4F14200891427 /* libalgoliasearch-client-objc.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 591C933318E265C3001F1A0F /* libalgoliasearch-client-objc.a */; settings = {ATTRIBUTES = (Required, ); }; };
 		599EA22D19EFB2D700FEF7E7 /* AppKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 599EA22619ED664700FEF7E7 /* AppKit.framework */; };
+		5D7B33401B4BBD7B00F12D56 /* ASExpiringCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 5D7B333F1B4BBD7B00F12D56 /* ASExpiringCache.m */; };
+		5D7B33431B4BBDEB00F12D56 /* ASExpiringCacheItem.m in Sources */ = {isa = PBXBuildFile; fileRef = 5D7B33421B4BBDEB00F12D56 /* ASExpiringCacheItem.m */; };
 		5D85ED221B28659A001C1C5B /* ASBrowseIterator.m in Sources */ = {isa = PBXBuildFile; fileRef = 5D85ED211B28659A001C1C5B /* ASBrowseIterator.m */; };
 		88FF96774A8D4C439B606454 /* libPods.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 454533AE49614E8FA1210C4D /* libPods.a */; settings = {ATTRIBUTES = (Required, ); }; };
 /* End PBXBuildFile section */
@@ -68,6 +70,10 @@
 		591C936418E267B5001F1A0F /* ASRemoteIndex.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASRemoteIndex.m; sourceTree = "<group>"; };
 		599EA22119ED5E9A00FEF7E7 /* libPods-AFNetworking.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = "libPods-AFNetworking.a"; path = "../../../Library/Developer/Xcode/DerivedData/algoliasearch-client-objc-ezaqtrvmayymwwavbcfvoeuiphpx/Build/Products/Debug/libPods-AFNetworking.a"; sourceTree = "<group>"; };
 		599EA22619ED664700FEF7E7 /* AppKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppKit.framework; path = System/Library/Frameworks/AppKit.framework; sourceTree = SDKROOT; };
+		5D7B333E1B4BBD7B00F12D56 /* ASExpiringCache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASExpiringCache.h; sourceTree = "<group>"; };
+		5D7B333F1B4BBD7B00F12D56 /* ASExpiringCache.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASExpiringCache.m; sourceTree = "<group>"; };
+		5D7B33411B4BBDEB00F12D56 /* ASExpiringCacheItem.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASExpiringCacheItem.h; sourceTree = "<group>"; };
+		5D7B33421B4BBDEB00F12D56 /* ASExpiringCacheItem.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASExpiringCacheItem.m; sourceTree = "<group>"; };
 		5D85ED201B28659A001C1C5B /* ASBrowseIterator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASBrowseIterator.h; sourceTree = "<group>"; };
 		5D85ED211B28659A001C1C5B /* ASBrowseIterator.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASBrowseIterator.m; sourceTree = "<group>"; };
 		93A3C6D5C4BEC322D8180EA7 /* Pods.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.release.xcconfig; path = "Pods/Target Support Files/Pods/Pods.release.xcconfig"; sourceTree = "<group>"; };
@@ -174,6 +180,10 @@
 				591C936418E267B5001F1A0F /* ASRemoteIndex.m */,
 				5D85ED201B28659A001C1C5B /* ASBrowseIterator.h */,
 				5D85ED211B28659A001C1C5B /* ASBrowseIterator.m */,
+				5D7B333E1B4BBD7B00F12D56 /* ASExpiringCache.h */,
+				5D7B333F1B4BBD7B00F12D56 /* ASExpiringCache.m */,
+				5D7B33411B4BBDEB00F12D56 /* ASExpiringCacheItem.h */,
+				5D7B33421B4BBDEB00F12D56 /* ASExpiringCacheItem.m */,
 			);
 			path = src;
 			sourceTree = "<group>";
@@ -339,6 +349,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				5D7B33401B4BBD7B00F12D56 /* ASExpiringCache.m in Sources */,
+				5D7B33431B4BBDEB00F12D56 /* ASExpiringCacheItem.m in Sources */,
 				591C936718E267B5001F1A0F /* ASQuery.m in Sources */,
 				591C936518E267B5001F1A0F /* ASAPIClient+Network.m in Sources */,
 				591C936818E267B5001F1A0F /* ASRemoteIndex.m in Sources */,

--- a/src/ASExpiringCache.h
+++ b/src/ASExpiringCache.h
@@ -1,0 +1,40 @@
+//
+//  Copyright (c) 2013 Algolia
+//  http://www.algolia.com/
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface ASExpiringCache : NSObject
+
+- (instancetype)initWithExpiringTimeInterval:(NSTimeInterval)eti;
+
+- (void)dealloc;
+
+- (NSDictionary*)objectForKey:(NSString*)key;
+
+- (void)setObject:(NSDictionary*)obj forKey:(NSString*)key;
+
+- (void)clearCache;
+
+- (void)clearExpiredCache;
+
+@end

--- a/src/ASExpiringCache.m
+++ b/src/ASExpiringCache.m
@@ -1,0 +1,94 @@
+//
+//  Copyright (c) 2013 Algolia
+//  http://www.algolia.com/
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+#import "ASExpiringCache.h"
+#import "ASExpiringCacheItem.h"
+
+@implementation ASExpiringCache {
+    NSCache *cache;
+    NSTimeInterval expiringTimeInterval;
+    
+    NSMutableArray *cacheKeys;
+    NSTimer *timer;
+}
+
+- (instancetype)initWithExpiringTimeInterval:(NSTimeInterval)eti {
+    self = [super init];
+    if (self) {
+        expiringTimeInterval = eti;
+        cache = [[NSCache alloc] init];
+        cacheKeys = [NSMutableArray array];
+        
+        // Garbage collector like, for the expired cache
+        timer = [NSTimer timerWithTimeInterval:(2 * eti) target:self selector:@selector(clearExpiredCache) userInfo:nil repeats:YES];
+        timer.tolerance = eti * 0.5;
+        [[NSRunLoop mainRunLoop] addTimer:timer forMode:NSDefaultRunLoopMode];
+    }
+    return self;
+}
+
+- (void)dealloc {
+    [timer invalidate];
+}
+
+- (NSDictionary*)objectForKey:(NSString*)key {
+    ASExpiringCacheItem *object = [cache objectForKey:key];
+    if (object != nil) {
+        if ([object hasExpired:expiringTimeInterval]) {
+            [cache removeObjectForKey:key];
+        } else {
+            return object.content;
+        }
+    }
+    
+    return nil;
+}
+
+- (void)setObject:(NSDictionary*)obj forKey:(NSString*)key {
+    [cache setObject:[ASExpiringCacheItem newItem:obj] forKey:key];
+    [cacheKeys addObject:key];
+}
+
+- (void)clearCache {
+    [cache removeAllObjects];
+    [cacheKeys removeAllObjects];
+}
+
+- (void)clearExpiredCache {
+    NSMutableArray *tmp = [NSMutableArray array];
+    
+    for (int i = 0; i < [cacheKeys count]; ++i) {
+        ASExpiringCacheItem *object = [cache objectForKey:cacheKeys[i]];
+        if (object != nil) {
+            if ([object hasExpired:expiringTimeInterval]) {
+                [cache removeObjectForKey:cacheKeys[i]];
+            } else {
+                [tmp addObject:cacheKeys[i]];
+            }
+        }
+    }
+    
+    cacheKeys = tmp;
+}
+
+@end

--- a/src/ASExpiringCacheItem.h
+++ b/src/ASExpiringCacheItem.h
@@ -1,0 +1,35 @@
+//
+//  Copyright (c) 2013 Algolia
+//  http://www.algolia.com/
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface ASExpiringCacheItem : NSObject
+
++ (instancetype)newItem:(NSDictionary*)content;
+
+- (BOOL)hasExpired:(NSTimeInterval)expiringTimeInterval;
+
+@property (nonatomic) NSDictionary *content;
+@property (nonatomic) NSDate *expiringCacheItemDate;
+
+@end

--- a/src/ASExpiringCacheItem.m
+++ b/src/ASExpiringCacheItem.m
@@ -1,0 +1,51 @@
+//
+//  Copyright (c) 2013 Algolia
+//  http://www.algolia.com/
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+#import "ASExpiringCacheItem.h"
+
+@interface ASExpiringCacheItem ()
+
+- (instancetype)initWithContent:(NSDictionary*)content;
+
+@end
+
+@implementation ASExpiringCacheItem
+
++ (instancetype)newItem:(NSDictionary*)content {
+    return [[self.class alloc] initWithContent:content];
+}
+
+- (instancetype)initWithContent:(NSDictionary*)content {
+    self = [super init];
+    if (self) {
+        _content = content;
+        _expiringCacheItemDate = [NSDate date];
+    }
+    return self;
+}
+
+- (BOOL)hasExpired:(NSTimeInterval)expiringTimeInterval {
+    return fabs([self.expiringCacheItemDate timeIntervalSinceNow]) > expiringTimeInterval;
+}
+
+@end

--- a/src/ASRemoteIndex.h
+++ b/src/ASRemoteIndex.h
@@ -436,6 +436,28 @@
  */
 -(void) cancelPreviousSearches;
 
+/**
+ * Enable search cache.
+ */
+- (void)enableSearchCache;
+
+/**
+ * Enable search cache.
+ * 
+ * @param eti Each cached search will be valid during this interval of time
+ */
+- (void)enableSearchCacheWithExpiringTimeInterval:(NSTimeInterval)eti;
+
+/**
+ * Disable search cache
+ */
+- (void)disableSearchCache;
+
+/**
+ * Clear search cache
+ */
+- (void)clearSearchCache;
+
 @property (nonatomic)           NSString     *indexName;
 @property (readonly, nonatomic) ASAPIClient  *apiClient;
 @property (nonatomic)           NSString     *urlEncodedIndexName;


### PR DESCRIPTION
Same features as the Swift API Client.

* Disabled by default.
* Simple setup: `[myIndex enableSearchCache];`
* Auto-remove expired cache (Garbage Collection like)
* Configurable expiring time interval (default to 2 min)
* Cache search query only

cc @redox @speedblue 