### PR TITLE
Adds analyticsTags to query

### DIFF
--- a/src/ASQuery.h
+++ b/src/ASQuery.h
@@ -276,6 +276,11 @@
 @property (nonatomic) NSString            *aroundLatLong;
 
 /**
+ * Tags can be used in the Analytics to analyze a subset of searches only. Comma-separated string list like @[@"ios", @"web"]
+ */
+@property (nonatomic) NSArray            *analyticsTags;
+
+/**
  * If set to YES use geolocation via client IP instead of passing a latitude/longitude manually
  */
 @property BOOL                             aroundLatLongViaIP;

--- a/src/ASQuery.m
+++ b/src/ASQuery.m
@@ -72,6 +72,7 @@
         _restrictSearchableAttributes = nil;
         _highlightPreTag = nil;
         _highlightPostTag = nil;
+        _analyticsTags = nil;
     }
     return self;
 }
@@ -111,6 +112,7 @@
     new.restrictSearchableAttributes = [self.restrictSearchableAttributes copyWithZone:zone];
     new.highlightPreTag = [self.highlightPreTag copyWithZone:zone];
     new.highlightPostTag = [self.highlightPostTag copyWithZone:zone];
+    new.analyticsTags = [self.analyticsTags copyWithZone:zone];
     
     return new;
 }
@@ -354,6 +356,18 @@
         if ([stringBuilder length] > 0)
             [stringBuilder appendString:@"&"];
         [stringBuilder appendFormat:@"highlightPostTag=%@", [ASAPIClient urlEncode:self.highlightPostTag]];
+    }
+    if (self.analyticsTags != nil) {
+        if ([stringBuilder length] > 0)
+            [stringBuilder appendString:@"&"];
+        [stringBuilder appendString:@"analyticsTags="];
+        BOOL first = YES;
+        for (NSString* tag in self.analyticsTags) {
+            if (!first)
+                [stringBuilder appendString:@","];
+            [stringBuilder appendString:[ASAPIClient urlEncode:tag]];
+            first = NO;
+        }
     }
     return stringBuilder;
 }


### PR DESCRIPTION
### Scope
- [x] Add support for `analyticsTags` query parameter https://www.algolia.com/doc/objc#QueryParameters

### Use-case
We are looking to segment our search analytics by client at ProductHunt.